### PR TITLE
Problem: keeping values on the stack or repeating code is not fun

### DIFF
--- a/doc/script/SET.md
+++ b/doc/script/SET.md
@@ -1,0 +1,47 @@
+# SET
+
+Sets a word value.
+
+Input stack: `c`
+
+Output stack:
+
+Since it is rather bothersome to keep certain values (like handles
+or strings) around by manipulating the stack, it'd be nice to be able
+to refer to them directly.
+
+It's syntax is rather interesting:
+
+```
+[<word name> : ...code...] SET
+```
+
+`SET` allows to define a value of a word for the scope of the script's
+remainder. Keep in mind that `SET` does not evaluate the expression
+after <word name>, it simply stores. In effect, each time <word name>
+is called, it's re-evaluated again.
+
+## Allocation
+
+None
+
+## Errors
+
+EmptyStack error if there are less than two items on the stack
+
+It will error if the format of the closure is incorrect
+
+It may error if this word is a built-in word that was previously
+defined.
+
+## Examples
+
+```
+[key : "MyKey"] SET [key "value" ASSOC COMMIT] WRITE [key RETR] READ => "value"
+```
+
+## Tests
+
+```
+[key : "MyKey"] key => "MyKey"
+```

--- a/doc/script/SET.md
+++ b/doc/script/SET.md
@@ -10,20 +10,35 @@ Since it is rather bothersome to keep certain values (like handles
 or strings) around by manipulating the stack, it'd be nice to be able
 to refer to them directly.
 
-It's syntax is rather interesting:
+`SET` allows to define a value of a word for the scope of the script's
+remainder. 
+
+It's syntax is rather interesting. It has two forms, first one is this: 
 
 ```
 [<word name> : ...code...] SET
 ```
 
-`SET` allows to define a value of a word for the scope of the script's
-remainder. Keep in mind that `SET` does not evaluate the expression
-after <word name>, it simply stores. In effect, each time <word name>
+In this form, `SET` does not evaluate the expression
+after the colon, it simply stores it. In effect, each time <word name>
 is called, it's re-evaluated again.
+
+The second form is this:
+
+```
+[<word name> = ...code...] SET
+```
+
+This form immediately evaluates the expression after the equal sign and
+stores it. In effect, each time <word name> is called, the same value
+will be returned.
+
+
 
 ## Allocation
 
-None
+The second (immediate evaluation) form allocates runtime memory
+ for injecting binding code. The other form does not allocate.
 
 ## Errors
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#![feature(slice_patterns, advanced_slice_patterns)]
 #![cfg_attr(test, feature(test))]
 
 #![feature(alloc, heap_api)]

--- a/src/script/textparser.rs
+++ b/src/script/textparser.rs
@@ -89,7 +89,7 @@ fn sized_vec(s: Vec<u8>) -> Vec<u8> {
 
 fn is_word_char(s: u8) -> bool {
     (s >= b'a' && s <= b'z') || (s >= b'A' && s <= b'Z') || (s >= b'0' && s <= b'9') ||
-    s == b'_' || s == b':' || s == b'-' ||
+    s == b'_' || s == b':' || s == b'-' || s == b'=' ||
     s == b'!' || s == b'#' || s == b'$' || s == b'%' || s == b'@' || s == b'?' ||
     s == b'/'
 }


### PR DESCRIPTION
Since it is rather bothersome to keep certain values (like handles
or strings) around by manipulating the stack, it'd be nice to be able
to refer to them directly.

Solution: introduce `SET` word

It's syntax is rather interesting:

```
[<word name> : ...code...] SET
```

`SET` allows to define a value of a word for the scope of the script's
remainder. Keep in mind that `SET` does not evaluate the expression
after <word name>, it simply stores. In effect, each time <word name>
is called, it's re-evaluated again.

Another form of SET will evaluate the code immediately:

```
[<word name> =  ...code...] SET
```