### PR TITLE
Problem: impossible to compare byte arrays on the stack

### DIFF
--- a/doc/script/EQUALP.md
+++ b/doc/script/EQUALP.md
@@ -1,0 +1,30 @@
+# EQUAL?
+
+Compares to topmost items.
+
+Input stack:
+
+Output stack: `a`
+
+`EQUAL?` will push `1` if they are equal, `0` otherwise.
+
+## Allocation
+
+None
+
+## Errors
+
+EmptyStack error if there are less than two items on the stack
+
+## Examples
+
+```
+"Hello, " "world!" EQUAL => 0
+```
+
+## Tests
+
+```
+"Hello, " "world!" EQUAL => 0
+"Hello, " "Hello, " EQUAL => 1
+```


### PR DESCRIPTION
Solution: EQUAL? word, pops two items from the stack, if they are equal, pushes
1 on top of the stack, otherwise pushes 0

Fixes #5