### PR TITLE
Problem: number endianness was picked wrongly

### DIFF
--- a/doc/script/README.md
+++ b/doc/script/README.md
@@ -14,7 +14,7 @@ formats can it support, etc.
 PumpkinScript has no types, all values on the stack are byte arrays. However,
 there are some conventions:
 
-* Big integers represented as (unlimited length) little-endian byte arrays
+* Big integers represented as (unlimited length) big-endian byte arrays
 * Strings are represented as UTF-8 encoded byte arrays
 
 ## Text form
@@ -28,7 +28,7 @@ with binaries represented as:
 
 * `0x<hexadecimal>` (hexadecimal form)
 * `"STRING"` (string form, no quoted characters support yet)
-* `integer` (integer form, will convert to a little endian big integer)
+* `integer` (integer form, will convert to a big endian big integer)
 
 The rest of the instructions considered to be words.
 

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -633,7 +633,7 @@ impl<'a> VM<'a> {
     #[inline]
     fn handle_depth(&mut self, mut env: Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
         if word == DEPTH {
-            let bytes = BigUint::from(env.stack_size).to_bytes_le();
+            let bytes = BigUint::from(env.stack_size).to_bytes_be();
             let offset = offset_by_size(bytes.len());
             let slice = env.alloc(bytes.len() + offset);
             write_size_into_slice!(bytes.len(), slice);

--- a/src/script/textparser.rs
+++ b/src/script/textparser.rs
@@ -106,7 +106,7 @@ named!(uint<Vec<u8>>, do_parse!(
                      biguint: map_res!(
                                 map_res!(digit, str::from_utf8),
                                 BigUint::from_str)        >>
-                              (sized_vec(biguint.to_bytes_le()))));
+                              (sized_vec(biguint.to_bytes_be()))));
 named!(word<Vec<u8>>, do_parse!(
                         word: take_while1!(is_word_char)  >>
                               (prefix_word(word))));
@@ -135,7 +135,7 @@ named!(program<Vec<u8>>, do_parse!(
 ///
 /// * `0x<hexadecimal>` (hexadecimal form)
 /// * `"STRING"` (string form, no quoted characters support yet)
-/// * `integer` (integer form, will convert to a little endian big integer)
+/// * `integer` (integer form, will convert to a big endian big integer)
 ///
 /// The rest of the instructions considered to be words.
 ///
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn test_uint() {
         let script = parse("1234567890").unwrap();
-        let mut bytes = BigUint::from_str("1234567890").unwrap().to_bytes_le();
+        let mut bytes = BigUint::from_str("1234567890").unwrap().to_bytes_be();
         let mut sized = Vec::new();
         sized.push(4);
         sized.append(&mut bytes);


### PR DESCRIPTION
Little endian is obviously a bad choice for sorting (which is a huge
chunk of PumpkinDB's business). Sleep deprivation is real!

Solution: switch to big endian