### PR TITLE
Problem: persisting keys in binary script form is bad for traversing

### DIFF
--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -35,15 +35,6 @@ macro_rules! write_size_into_slice {
     };
 }
 
-macro_rules! data {
-    ($ptr:expr) => {
-        {
-          let (_, size) = binparser::data_size($ptr).unwrap();
-          (&$ptr[offset_by_size(size)..$ptr.len()], size)
-        }
-    };
-}
-
 macro_rules! handle_words {
     ($me: expr, $env: expr, $program: expr, $word: expr, $res: ident,
      $pid: ident, [ $($name: ident),* ], $block: expr) => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -111,10 +111,8 @@ impl<'a> Service for PlainServer<'a> {
 
                 for v in stack {
                     let _ = write!(&mut s, "0x");
-                    let (_, size) = script::binparser::data_size(v).unwrap();
-                    let offset = script::offset_by_size(size);
-                    for i in offset..offset + size - 1 {
-                        let _ = write!(&mut s, "{:X}", v[i]).unwrap();
+                    for b in v {
+                        let _ = write!(&mut s, "{:X}", b).unwrap();
                     }
                     let _ = write!(&mut s, " ");
                 }


### PR DESCRIPTION
Solution: make Env stack store references to data without their size prefixes
(as slices already have length) and hence we can move to persisting data as is
in the database. Having stack that was is not big of a deal because we can
write size prefixes on demand when we are sending data back, avoiding
allocations there.

Fixes #23