### PR TITLE
Problem: no ordering sequencer primitive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ lazy_static = "0.2.2"
 num-bigint = "0.1.35"
 num-traits = "0.1.36"
 libc = "0.2.20"
+hybrid-clocks = "0.3.2"
+byteorder = "1.0.0"
 
 [dev-dependencies]
 quickcheck = "0.4.1"

--- a/doc/script/HLC.md
+++ b/doc/script/HLC.md
@@ -1,0 +1,29 @@
+# HLC
+
+Pushes Hybrid Logical Timestamp onto the stack
+
+Input stack:
+
+Output stack: `a`
+
+Every timestamp is guaranteed to be unique and grow monotonically. 
+
+## Allocation
+
+Allocates for the timestamp to be pushed on stack.
+
+## Errors
+
+None
+
+## Examples
+
+```
+HLC => 0x000014A27859A0C2E2900000
+```
+
+## Tests
+
+```
+HLC HLC EQUAL? => 0
+```

--- a/doc/script/HLC/GTP.md
+++ b/doc/script/HLC/GTP.md
@@ -1,0 +1,31 @@
+# HLC/GT?
+
+Compares two topmost HLC items.
+
+Input stack: `a b`
+
+Output stack: `c`
+
+`HLC/GT?` will push `1` if `a` is strictly greater than `b`, `0` otherwise.
+
+## Allocation
+
+None
+
+## Errors
+
+EmptyStack error if there are less than two items on the stack
+
+It will fail if any of the top two items is not an HLC timestamp.
+
+## Examples
+
+```
+HLC HLC SWAP HLC/GT? => 1
+```
+
+## Tests
+
+```
+HLC HLC SWAP HLC/GT? => 1
+```

--- a/doc/script/HLC/LC.md
+++ b/doc/script/HLC/LC.md
@@ -1,0 +1,33 @@
+# HLC/LC
+
+Returns HLC timestamp's logical counter 
+
+Input stack: `a`
+
+Output stack: `b`
+
+Removes a topmost item off the stack (an HLC timestamp) and pushes
+its logical counter as a 4-byte big-endian number. 
+
+## Allocation
+
+Allocates for the logical counter to be pushed on stack.
+
+## Errors
+
+EmptyStack error if there are less than one item on the stack
+
+It will fail if the item is not an HLC timestamp.
+
+
+## Examples
+
+```
+HLC DUP HLC/TICK => 0x000014A278ED90AB13700000 0x000014A278ED90AB13700001
+```
+
+## Tests
+
+```
+HLC DUP HLC/TICK HLC/LT? => 1
+```

--- a/doc/script/HLC/LTP.md
+++ b/doc/script/HLC/LTP.md
@@ -1,0 +1,31 @@
+# HLC/LT?
+
+Compares two topmost HLC items.
+
+Input stack: `a b`
+
+Output stack: `c`
+
+`HLC/LT?` will push `1` if `a` is strictly lesser than `b`, `0` otherwise.
+
+## Allocation
+
+None
+
+## Errors
+
+EmptyStack error if there are less than two items on the stack
+
+It will fail if any of the top two items is not an HLC timestamp.
+
+## Examples
+
+```
+HLC HLC HLC/LT? => 1
+```
+
+## Tests
+
+```
+HLC HLC HLC/LT? => 1
+```

--- a/doc/script/HLC/TICK.md
+++ b/doc/script/HLC/TICK.md
@@ -1,0 +1,33 @@
+# HLC/TICK
+
+Increments a logical counter in an HLC timestamp 
+
+Input stack: `a`
+
+Output stack: `b`
+
+Removes a topmost item off the stack (an HLC timestamp) and increments
+a logical counter, without updating the wall clock part. 
+
+## Allocation
+
+Allocates for the new timestamp to be pushed on stack.
+
+## Errors
+
+EmptyStack error if there are less than one item on the stack
+
+It will fail if the item is not an HLC timestamp.
+
+
+## Examples
+
+```
+HLC DUP HLC/TICK => 0x000014A278ED90AB13700000 0x000014A278ED90AB13700001
+```
+
+## Tests
+
+```
+HLC DUP HLC/TICK HLC/LT? => 1
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,10 @@ extern crate tokio_core;
 extern crate tokio_proto;
 extern crate tokio_service;
 
+extern crate hybrid_clocks as hlc;
+
+extern crate byteorder;
+
 extern crate config;
 
 #[macro_use]
@@ -44,6 +48,7 @@ extern crate lazy_static;
 
 pub mod script;
 pub mod server;
+pub mod timestamp;
 
 use std::thread;
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2017, All Contributors (see CONTRIBUTORS file)
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use hlc;
+use std::sync::Mutex;
+
+lazy_static! {
+
+   static ref HLC_CLOCK: Mutex<hlc::Clock<hlc::Wall>> = Mutex::new(hlc::Clock::wall());
+
+}
+
+pub fn hlc() -> hlc::Timestamp<hlc::WallT> {
+    (*HLC_CLOCK).lock().unwrap().now()
+}
+
+#[cfg(test)]
+mod tests {
+
+    use timestamp;
+
+    #[test]
+    fn test() {
+        let t1 = timestamp::hlc();
+        let t2 = timestamp::hlc();
+        assert!(t2 > t1);
+    }
+}


### PR DESCRIPTION
In event-sourced systems it often makes sense to
have a unique, monotonically growing sequencer for journalling.

Solution: implement a set of words for HLC (Hybrid Logical Clocks,
https://www.cse.buffalo.edu/tech-reports/2014-04.pdf)

It carries both wall clock timestamp and a logical counter and is guaranteed to
provide unique values every time.

Eventually we may (or may be even should) have other sequencers as well.