### PR TITLE
Handle null pointers when (re)-allocating Env

### DIFF
--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -513,7 +513,11 @@ impl<'a> VM<'a> {
     }
 
     fn pass(&mut self, mut env: Env<'a>, program: &mut Vec<u8>, pid: EnvId) -> PassResult<'a> {
-        let mut slice = env.alloc(program.len());
+        let slice0 = env.alloc(program.len());
+        if slice0.is_err() {
+            return Err((env, slice0.unwrap_err()));
+        }
+        let mut slice = slice0.unwrap();
         for i in 0..program.len() {
             slice[i] = program[i];
         }
@@ -669,7 +673,11 @@ impl<'a> VM<'a> {
     fn handle_depth(&mut self, mut env: Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
         if word == DEPTH {
             let bytes = BigUint::from(env.stack_size).to_bytes_be();
-            let slice = env.alloc(bytes.len());
+            let slice0 = env.alloc(bytes.len());
+            if slice0.is_err() {
+                return Err((env, slice0.unwrap_err()));
+            }
+            let mut slice = slice0.unwrap();
             for i in 0..bytes.len() {
                 slice[i] = bytes[i];
             }
@@ -768,8 +776,11 @@ impl<'a> VM<'a> {
             let a1 = a.unwrap();
             let b1 = b.unwrap();
 
-            let mut slice = env.alloc(a1.len() + b1.len());
-
+            let slice0 = env.alloc(a1.len() + b1.len());
+            if slice0.is_err() {
+                return Err((env, slice0.unwrap_err()));
+            }
+            let mut slice = slice0.unwrap();
             let mut offset = 0;
 
             for byte in b1 {
@@ -893,7 +904,11 @@ impl<'a> VM<'a> {
                     let word = &closure[0..closure.len()];
                     let offset = offset_by_size(val.len());
                     let sz = val.len() + offset;
-                    let mut slice = env.alloc(sz);
+                    let slice0 = env.alloc(sz);
+                    if slice0.is_err() {
+                        return Err((env, slice0.unwrap_err()))
+                    }
+                    let mut slice = slice0.unwrap();
                     write_size_into_slice!(val.len(), &mut slice);
                     let mut i = offset;
                     for b in val {

--- a/src/script/storage.rs
+++ b/src/script/storage.rs
@@ -165,7 +165,11 @@ impl<'a> Handler<'a> {
 
             return match access.get::<[u8], [u8]>(self.db, key1).to_opt() {
                 Ok(Some(val)) => {
-                    let slice = env.alloc(val.len());
+                    let slice0 = env.alloc(val.len());
+                    if slice0.is_err() {
+                        return Err((env, slice0.unwrap_err()))
+                    }
+                    let mut slice = slice0.unwrap();
                     for i in 0..val.len() {
                         slice[i] = val[i];
                     }

--- a/src/script/timestamp_hlc.rs
+++ b/src/script/timestamp_hlc.rs
@@ -36,7 +36,11 @@ impl<'a> Handler<'a> {
     pub fn handle_hlc(&mut self, mut env: Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
         if word == HLC {
             let now = timestamp::hlc();
-            let mut slice = env.alloc(16);
+            let slice0 = env.alloc(16);
+            if slice0.is_err() {
+                return Err((env, slice0.unwrap_err()));
+            }
+            let mut slice = slice0.unwrap();
             let _ = now.write_bytes(&mut slice[0..]).unwrap();
             env.push(slice);
             Ok((env, None))
@@ -135,7 +139,11 @@ impl<'a> Handler<'a> {
             let mut t1 = t1_.unwrap();
             t1.count += 1;
 
-            let mut slice = env.alloc(16);
+            let slice0 = env.alloc(16);
+            if slice0.is_err() {
+                return Err((env, slice0.unwrap_err()));
+            }
+            let slice = slice0.unwrap();
             let _ = t1.write_bytes(&mut slice[0..]).unwrap();
             env.push(slice);
 
@@ -164,7 +172,11 @@ impl<'a> Handler<'a> {
 
             let t1 = t1_.unwrap();
 
-            let mut slice = env.alloc(4);
+            let slice0 = env.alloc(4);
+            if slice0.is_err() {
+                return Err((env, slice0.unwrap_err()));
+            }
+            let slice = slice0.unwrap();
             let _ = (&mut slice[0..]).write_u32::<BigEndian>(t1.count);
 
             env.push(slice);


### PR DESCRIPTION
Problem:  Problem: heap [re]allocation failure will lead to a process crash #17 

Solution: Use rust's null pointer check (`as_mut` and `as_ref`) to check the value
of the heap allocation result, and return a `Result` instead of a guaranteed
success. Handle possible failure cases where needed (by just propagating the
error towards the call site).