### PR TITLE
Problem: Being able to negate a boolean is important

### DIFF
--- a/doc/script/NOT.md
+++ b/doc/script/NOT.md
@@ -1,0 +1,31 @@
+# NOT
+
+Negates a boolean value.
+
+Input stack: `a`
+
+Output stack: `c`
+
+`NOT` will push `1` if `a` is `0` and `0` if `a` is `1`.
+
+## Allocation
+
+None
+
+## Errors
+
+InvalidValue error if the value being negated is not a boolean.
+
+## Examples
+
+```
+0x01 NOT => 0
+0x00 NOT => 1
+```
+
+## Tests
+
+```
+0x00 NOT => 1
+0x01 NOT => 0
+```


### PR DESCRIPTION
As a stepping stone towards implementing powerful control flow words like `IF`, having a
way to negate a boolean value is helpful.