### PR TITLE
Problem: impossible to extract a portion of a byte array

### DIFF
--- a/doc/script/SLICE.md
+++ b/doc/script/SLICE.md
@@ -1,0 +1,38 @@
+# SLICE
+
+Pushes a subset of a byte array onto the stack
+
+Input stack: `data start end`
+
+Output stack: `new_data`
+
+SLICE pushes a subset from include `start` to exclusive `end`
+to the top of the stack.
+
+## Allocation
+
+Allocated in runtime to parse start/end numbers. Sliced
+array is zero-copy.
+
+## Errors
+
+EmptyStack error if there are less than three items on the stack
+
+InvalidValue error if `start` is larger than data length.
+
+InvalidValue error if `start` is lesser than `end`.
+
+InvalidValue error if `end` is larger than data length.
+ 
+
+## Examples
+
+```
+0x102030 1 3 SLICE => 0x2030
+```
+
+## Tests
+
+```
+0x102030 1 3 SLICE => 0x2030
+```

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -64,6 +64,7 @@ use alloc::heap;
 
 use num_bigint::BigUint;
 use num_traits::{Zero, One};
+use num_traits::ToPrimitive;
 use core::ops::Sub;
 use std::cmp;
 
@@ -110,6 +111,7 @@ word!(LTP, (a, b => c), b"\x83LT?");
 word!(GTP, (a, b => c), b"\x83GT?");
 word!(LENGTH, (a => b), b"\x86LENGTH");
 word!(CONCAT, (a, b => c), b"\x86CONCAT");
+word!(SLICE, (a, b, c => d), b"\x85SLICE");
 
 // Category: Control flow
 word!(TIMES, b"\x85TIMES");
@@ -579,6 +581,7 @@ impl<'a> VM<'a> {
                            self => handle_gtp,
                            self => handle_equal,
                            self => handle_concat,
+                           self => handle_slice,
                            self => handle_length,
                            self => handle_times,
                            self => handle_eval,
@@ -886,6 +889,37 @@ impl<'a> VM<'a> {
             }
 
             env.push(slice);
+
+            Ok((env, None))
+        } else {
+            Err((env, Error::UnknownWord))
+        }
+    }
+
+    #[inline]
+    fn handle_slice(&mut self, mut env: Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
+        if word == SLICE {
+            let end = stack_pop!(env);
+            let start = stack_pop!(env);
+            let slice = stack_pop!(env);
+
+            let start_int = BigUint::from_bytes_be(start).to_u64().unwrap() as usize;
+            let end_int = BigUint::from_bytes_be(end).to_u64().unwrap() as usize;
+
+            // range conditions
+            if start_int > end_int {
+                return Err((env, Error::InvalidValue));
+            }
+
+            if start_int > slice.len() - 1 {
+                return Err((env, Error::InvalidValue));
+            }
+
+            if end_int > slice.len() {
+                return Err((env, Error::InvalidValue));
+            }
+
+            env.push(&slice[start_int..end_int]);
 
             Ok((env, None))
         } else {
@@ -1330,6 +1364,50 @@ mod tests {
         eval!("CONCAT", env, result, {
             assert!(matches!(result.err(), Some(Error::EmptyStack)));
         });
+    }
+
+    #[test]
+    fn slice() {
+        eval!("\"Hello\" 0 5 SLICE", env, {
+            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("\"Hello\""));
+            assert_eq!(env.pop(), None);
+        });
+
+        eval!("\"Hello\" 1 4 SLICE", env, {
+            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("\"ell\""));
+            assert_eq!(env.pop(), None);
+        });
+
+
+        eval!("\"Hello\" 0 0 SLICE", env, {
+            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("\"\""));
+            assert_eq!(env.pop(), None);
+        });
+
+        eval!("\"Hello\" 4 2 SLICE", env, result, {
+            assert!(matches!(result.err(), Some(Error::InvalidValue)));
+        });
+
+        eval!("\"Hello\" 5 7 SLICE", env, result, {
+            assert!(matches!(result.err(), Some(Error::InvalidValue)));
+        });
+
+        eval!("\"Hello\" 1 7 SLICE", env, result, {
+            assert!(matches!(result.err(), Some(Error::InvalidValue)));
+        });
+
+        eval!("0 1 SLICE", env, result, {
+            assert!(matches!(result.err(), Some(Error::EmptyStack)));
+        });
+
+        eval!("1 SLICE", env, result, {
+            assert!(matches!(result.err(), Some(Error::EmptyStack)));
+        });
+
+        eval!("SLICE", env, result, {
+            assert!(matches!(result.err(), Some(Error::EmptyStack)));
+        });
+
     }
 
     #[test]

--- a/src/script/textparser.rs
+++ b/src/script/textparser.rs
@@ -136,9 +136,10 @@ named!(binary<Vec<u8>>, do_parse!(
                          hex: take_while1!(is_hex_digit)  >>
                               (bin(hex))
 ));
-named!(string<Vec<u8>>, do_parse!(
+named!(string<Vec<u8>>,  alt!(do_parse!(tag!(b"\"\"") >> (vec![0])) |
+                         do_parse!(
                          str: delimited!(char!('"'), is_not!("\""), char!('"')) >>
-                              (string_to_vec(str))));
+                              (string_to_vec(str)))));
 named!(code<Vec<u8>>, do_parse!(
                          prog: delimited!(char!('['), ws!(program), char!(']')) >>
                                (sized_vec(prog))));
@@ -266,6 +267,14 @@ mod tests {
 
         assert_eq!(script, vec![0x02, 0xAA, 0xBB, 0x83, b'D', b'U', b'P',
                                 0x03, 0xFF, 0x00, 0xCC, 0x05, b'H', b'e', b'l', b'l', b'o']);
+    }
+
+
+    #[test]
+    fn test_empty_string() {
+        let script = parse("\"\"").unwrap();
+
+        assert_eq!(script, vec![0]);
     }
 
     #[test]


### PR DESCRIPTION
This is important when (for example) comparing key prefixes

Solution: SLICE word that would take a byte array, start index and end index
and push back a slice of that array.

Also, it was discovered that an empty string syntax ("") was
incorrectly parsed to an empty vector, so this has been fixed as well.

Closes #28