### PR TITLE
Problem: capturing stack at once is not trivial

### DIFF
--- a/doc/script/STACK.md
+++ b/doc/script/STACK.md
@@ -1,0 +1,33 @@
+# STACK
+
+Takes the entire stack and pushes it back as a byte array
+
+Input stack: `...`
+
+Output stack: `a`
+
+`STACK` takes the entire stack and pushes it as a binary
+form PumpkinScript onto the stack. If passed to [UNWRAP](UNWRAP.md),
+the same stack will be restored.
+
+## Allocation
+
+Allocates for the new values
+
+## Errors
+
+None
+
+## Examples
+
+```
+1 2 3 STACK => 0x111213
+1 2 3 STACK UNWRAP => 0x1 0x2 0x3
+```
+
+## Tests
+
+```
+1 2 3 STACK => 0x111213
+1 2 3 STACK UNWRAP => 0x1 0x2 0x3
+```


### PR DESCRIPTION
This is an upcoming problem. My current thinking that the server should only be
a binary packet streaming server, and those who want to play with PumpkinDB
using text form, should use a command-line PumpkinDB client (we can call it
pumpkindb-term) that will compile code to binary form and send it over.

The idea is that when a binary form is received by the server and evaluated the
resulting stack is simply discarded as there's no way to know just how much of
the stack the requestor actually want.

But stack will sometimes need to be captured. The only way to communicate back
from the script to the requestor (or other parties, for that matter) is to use
pubsub capabilities of the server.

How do we do that?

Solution: introduce STACK word that captures the entire stack into one
value.

Closes #29