### PR TITLE
Problem: SET syntax is not composable

### DIFF
--- a/doc/script/CURSOR.md
+++ b/doc/script/CURSOR.md
@@ -23,7 +23,7 @@ NoTransaction error if there's no current write transaction
 ## Examples
 
 ```
-[[c = CURSOR] SET ...] READ
+[CURSOR 'c SET ...] READ
 ```
 
 ## Tests

--- a/doc/script/CURSOR/CUR.md
+++ b/doc/script/CURSOR/CUR.md
@@ -23,11 +23,11 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ## Examples
 
 ```
-["1" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST DROP c CURSOR/CUR] READ UNWRAP => "1" "2"
+["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST DROP c CURSOR/CUR] READ UNWRAP => "1" "2"
 ```
 
 ## Tests
 
 ```
-["1" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST DROP c CURSOR/CUR] READ UNWRAP => "1" "2"
+["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST DROP c CURSOR/CUR] READ UNWRAP => "1" "2"
 ```

--- a/doc/script/CURSOR/CURP.md
+++ b/doc/script/CURSOR/CURP.md
@@ -22,11 +22,11 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ## Examples
 
 ```
-["1" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST DROP c CURSOR/CUR?] READ UNWRAP => 1
+["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST DROP c CURSOR/CUR?] READ UNWRAP => 1
 ```
 
 ## Tests
 
 ```
-["1" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST DROP c CURSOR/CUR?] READ UNWRAP => 1
+["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST DROP c CURSOR/CUR?] READ UNWRAP => 1
 ```

--- a/doc/script/CURSOR/FIRST.md
+++ b/doc/script/CURSOR/FIRST.md
@@ -23,11 +23,11 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ## Examples
 
 ```
-["1" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST] READ UNWRAP => "1" "2"
+["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST] READ UNWRAP => "1" "2"
 ```
 
 ## Tests
 
 ```
-["1" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST] READ UNWRAP => "1" "2"
+["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST] READ UNWRAP => "1" "2"
 ```

--- a/doc/script/CURSOR/FIRSTP.md
+++ b/doc/script/CURSOR/FIRSTP.md
@@ -24,11 +24,11 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ## Examples
 
 ```
-["1" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST?] READ => 1
+["1" "2" ASSOC COMMIT] WRITE [  CURSOR 'c SET c CURSOR/FIRST?] READ => 1
 ```
 
 ## Tests
 
 ```
-["1" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST?] READ  => 1
+["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST?] READ  => 1
 ```

--- a/doc/script/CURSOR/LAST.md
+++ b/doc/script/CURSOR/LAST.md
@@ -23,11 +23,11 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ## Examples
 
 ```
-["1" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/LAST] READ UNWRAP => "1" "2"
+["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/LAST] READ UNWRAP => "1" "2"
 ```
 
 ## Tests
 
 ```
-["1" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/LAST] READ UNWRAP => "1" "2"
+["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/LAST] READ UNWRAP => "1" "2"
 ```

--- a/doc/script/CURSOR/LASTP.md
+++ b/doc/script/CURSOR/LASTP.md
@@ -24,11 +24,11 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ## Examples
 
 ```
-["1" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/LAST?] READ => 1
+["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/LAST?] READ => 1
 ```
 
 ## Tests
 
 ```
-["1" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/LAST?] READ  => 1
+["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/LAST?] READ  => 1
 ```

--- a/doc/script/CURSOR/NEXT.md
+++ b/doc/script/CURSOR/NEXT.md
@@ -23,11 +23,11 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ## Examples
 
 ```
-["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST DROP c CURSOR/NEXT] READ UNWRAP => "2" "2"
+["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST DROP c CURSOR/NEXT] READ UNWRAP => "2" "2"
 ```
 
 ## Tests
 
 ```
-["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST DROP c CURSOR/NEXT] READ UNWRAP => "2" "2"
+["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST DROP c CURSOR/NEXT] READ UNWRAP => "2" "2"
 ```

--- a/doc/script/CURSOR/NEXTP.md
+++ b/doc/script/CURSOR/NEXTP.md
@@ -24,11 +24,11 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ## Examples
 
 ```
-["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST DROP c CURSOR/NEXT?] READ  => 1
+["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST DROP c CURSOR/NEXT?] READ  => 1
 ```
 
 ## Tests
 
 ```
-["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST DROP c CURSOR/NEXT?] READ  => 1
+["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST DROP c CURSOR/NEXT?] READ  => 1
 ```

--- a/doc/script/CURSOR/PREV.md
+++ b/doc/script/CURSOR/PREV.md
@@ -23,11 +23,11 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ## Examples
 
 ```
-["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/LAST DROP c CURSOR/PREV] READ UNWRAP => "1" "2"
+["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/LAST DROP c CURSOR/PREV] READ UNWRAP => "1" "2"
 ```
 
 ## Tests
 
 ```
-["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/LAST DROP c CURSOR/PREV] READ UNWRAP => "1" "2"
+["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/LAST DROP c CURSOR/PREV] READ UNWRAP => "1" "2"
 ```

--- a/doc/script/CURSOR/PREVP.md
+++ b/doc/script/CURSOR/PREVP.md
@@ -24,11 +24,11 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ## Examples
 
 ```
-["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/LAST DROP c CURSOR/PREV?] READ => 1
+["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/LAST DROP c CURSOR/PREV?] READ => 1
 ```
 
 ## Tests
 
 ```
-["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/LAST DROP c CURSOR/PREV?] READ => 1
+["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/LAST DROP c CURSOR/PREV?] READ => 1
 ```

--- a/doc/script/CURSOR/SEEK.md
+++ b/doc/script/CURSOR/SEEK.md
@@ -24,11 +24,11 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ## Examples
 
 ```
-["3" "3" ASSOC COMMIT] WRITE [[c = CURSOR] SET c "2" CURSOR/SEEK] READ UNWRAP => "3" "3"
+["3" "3" ASSOC COMMIT] WRITE [CURSOR 'c SET c "2" CURSOR/SEEK] READ UNWRAP => "3" "3"
 ```
 
 ## Tests
 
 ```
-["3" "3" ASSOC COMMIT] WRITE [[c = CURSOR] SET c "2" CURSOR/SEEK] READ UNWRAP => "3" "3"
+["3" "3" ASSOC COMMIT] WRITE [CURSOR 'c SET c "2" CURSOR/SEEK] READ UNWRAP => "3" "3"
 ```

--- a/doc/script/CURSOR/SEEKP.md
+++ b/doc/script/CURSOR/SEEKP.md
@@ -25,11 +25,11 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ## Examples
 
 ```
-["3" "3" ASSOC COMMIT] WRITE [[c = CURSOR] SET c "2" CURSOR/SEEK?] READ => 1
+["3" "3" ASSOC COMMIT] WRITE [CURSOR 'c SET c "2" CURSOR/SEEK?] READ => 1
 ```
 
 ## Tests
 
 ```
-["3" "3" ASSOC COMMIT] WRITE [[c = CURSOR] SET c "2" CURSOR/SEEK?] READ => 1
+["3" "3" ASSOC COMMIT] WRITE [CURSOR 'c SET c "2" CURSOR/SEEK?] READ => 1
 ```

--- a/doc/script/DEF.md
+++ b/doc/script/DEF.md
@@ -1,0 +1,43 @@
+# DEF
+
+Defines a word with a closure.
+
+Input stack: `c w`
+
+Output stack:
+
+Since it is rather bothersome to keep repeating code over and over,
+it'd be nice to be able define words as composites of other for the
+scope of the program.
+
+`DEF` allows to define word's program for the scope of the script's
+remainder.
+
+`DEF` will put the second topmost item off the stack (`c`) into the
+word referenced by top item (`w`)
+
+
+## Allocation
+
+None.
+
+## Errors
+
+EmptyStack error if there are less than two items on the stack
+
+It will error if the format of the word is incorrect
+
+It may error if this word is a built-in word that was previously
+defined.
+
+## Examples
+
+```
+[DUP DUP] 'dup2 DEF 1 dup2 => 1 1 1
+```
+
+## Tests
+
+```
+[DUP DUP] 'dup2 DEF 1 dup2 => 1 1 1
+```

--- a/doc/script/README.md
+++ b/doc/script/README.md
@@ -29,6 +29,7 @@ with binaries represented as:
 * `0x<hexadecimal>` (hexadecimal form)
 * `"STRING"` (string form, no quoted characters support yet)
 * `integer` (integer form, will convert to a big endian big integer)
+* `'word` (word in a binary form)
 
 The rest of the instructions considered to be words.
 

--- a/doc/script/SET.md
+++ b/doc/script/SET.md
@@ -1,8 +1,8 @@
 # SET
 
-Sets a word value.
+Sets a word to value.
 
-Input stack: `c`
+Input stack: `v w`
 
 Output stack:
 
@@ -13,38 +13,20 @@ to refer to them directly.
 `SET` allows to define a value of a word for the scope of the script's
 remainder. 
 
-It's syntax is rather interesting. It has two forms, first one is this: 
-
-```
-[<word name> : ...code...] SET
-```
-
-In this form, `SET` does not evaluate the expression
-after the colon, it simply stores it. In effect, each time <word name>
-is called, it's re-evaluated again.
-
-The second form is this:
-
-```
-[<word name> = ...code...] SET
-```
-
-This form immediately evaluates the expression after the equal sign and
-stores it. In effect, each time <word name> is called, the same value
-will be returned.
+`SET` will put the second topmost item off the stack (`v`) into the
+word referenced by top item (`w`)
 
 
 
 ## Allocation
 
-The second (immediate evaluation) form allocates runtime memory
- for injecting binding code. The other form does not allocate.
+Allocates on the heap for the binary form definition.
 
 ## Errors
 
 [EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
-It will error if the format of the closure is incorrect
+It will error if the format of the word is incorrect
 
 It may error if this word is a built-in word that was previously
 defined.
@@ -52,13 +34,13 @@ defined.
 ## Examples
 
 ```
-[assoc_and_commit : ASSOC COMMIT] SET ["key" "value" assoc_and_commit] WRITE ["key" RETR] READ => "value"
-[[c = CURSOR] SET c CURSOR/FIRST c CURSOR/NEXT] READ => <key> <val> <key> <val>
+[ASSOC COMMIT] 'assoc_and_commit SET ["key" "value" assoc_and_commit] WRITE ["key" RETR] READ => "value"
+[CURSOR 'c SET c CURSOR/FIRST c CURSOR/NEXT] READ => <key> <val> <key> <val>
 ```
 
 ## Tests
 
 ```
-[dup : DUP DUP] SET "MyKey" key => "MyKey" "MyKey" "MyKey"
-[depth = DEPTH] SET 1 2 3 depth => 0
+[DUP DUP] 'key SET "MyKey" key => "MyKey" "MyKey" "MyKey"
+DEPTH 'depth SET 1 2 3 depth => 0
 ```

--- a/src/script/storage.rs
+++ b/src/script/storage.rs
@@ -545,19 +545,19 @@ mod tests {
              assert!(result.is_err());
         });
 
-        eval!("[[c = CURSOR] SET] READ [c CURSOR/FIRST] READ", env, result, {
+        eval!("[CURSOR 'c SET] READ [c CURSOR/FIRST] READ", env, result, {
              assert!(result.is_err());
         });
-        eval!("[[c = CURSOR] SET] READ [c CURSOR/LAST] READ", env, result, {
+        eval!("[CURSOR 'c SET] READ [c CURSOR/LAST] READ", env, result, {
              assert!(result.is_err());
         });
-        eval!("[[c = CURSOR] SET] READ [c CURSOR/NEXT] READ", env, result, {
+        eval!("[CURSOR 'c SET] READ [c CURSOR/NEXT] READ", env, result, {
              assert!(result.is_err());
         });
-        eval!("[[c = CURSOR] SET] READ [c CURSOR/PREV] READ", env, result, {
+        eval!("[CURSOR 'c SET] READ [c CURSOR/PREV] READ", env, result, {
              assert!(result.is_err());
         });
-        eval!("[[c = CURSOR] SET] READ [1 c CURSOR/SEEK] READ", env, result, {
+        eval!("[CURSOR 'c SET] READ [1 c CURSOR/SEEK] READ", env, result, {
              assert!(result.is_err());
         });
 
@@ -580,19 +580,19 @@ mod tests {
              assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x01"));
         });
 
-        eval!("[1 2 ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST? DROP c CURSOR/NEXT?] READ", env, result, {
+        eval!("[1 2 ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST? DROP c CURSOR/NEXT?] READ", env, result, {
              assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x00"));
         });
 
-        eval!("[1 2 ASSOC 2 2 ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST? DROP c CURSOR/NEXT?] READ", env, result, {
+        eval!("[1 2 ASSOC 2 2 ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST? DROP c CURSOR/NEXT?] READ", env, result, {
              assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x01"));
         });
 
-        eval!("[1 2 ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/LAST? DROP c CURSOR/PREV?] READ", env, result, {
+        eval!("[1 2 ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/LAST? DROP c CURSOR/PREV?] READ", env, result, {
              assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x00"));
         });
 
-        eval!("[1 2 ASSOC 2 2 ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/LAST? DROP c CURSOR/LAST?] READ", env, result, {
+        eval!("[1 2 ASSOC 2 2 ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/LAST? DROP c CURSOR/LAST?] READ", env, result, {
              assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x01"));
         });
 
@@ -608,11 +608,11 @@ mod tests {
 
     #[test]
     fn cursor_cur() {
-        eval!("[1 2 ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST? [c CURSOR/CUR UNWRAP] IF] READ", env, result, {
+        eval!("[1 2 ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST? [c CURSOR/CUR UNWRAP] IF] READ", env, result, {
              assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x02"));
              assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x01"));
         });
-        eval!("[1 2 ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST? [c CURSOR/CUR?] IF] READ", env, result, {
+        eval!("[1 2 ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST? [c CURSOR/CUR?] IF] READ", env, result, {
              assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x01"));
         });
     }
@@ -625,7 +625,7 @@ mod tests {
         eval!("CURSOR/NEXT", env, result, {
              assert!(result.is_err());
         });
-        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST UNWRAP c CURSOR/NEXT UNWRAP] READ",
+        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST UNWRAP c CURSOR/NEXT UNWRAP] READ",
               env,
               result,
               {
@@ -636,7 +636,7 @@ mod tests {
                   assert_eq!(env.pop(), None);
               });
         // empty db => no first
-        eval!("[[c = CURSOR] SET c CURSOR/FIRST SOME?] READ",
+        eval!("[CURSOR 'c SET c CURSOR/FIRST SOME?] READ",
               env,
               result,
               {
@@ -644,7 +644,7 @@ mod tests {
                   assert_eq!(env.pop(), None);
               });
 
-        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC [c = CURSOR] SET c CURSOR/FIRST UNWRAP c CURSOR/NEXT UNWRAP] WRITE",
+        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC CURSOR 'c SET c CURSOR/FIRST UNWRAP c CURSOR/NEXT UNWRAP] WRITE",
               env,
               result,
               {
@@ -662,7 +662,7 @@ mod tests {
         eval!("CURSOR/LAST", env, result, {
              assert!(result.is_err());
         });
-        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/LAST UNWRAP] READ",
+        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/LAST UNWRAP] READ",
               env,
               result,
               {
@@ -672,7 +672,7 @@ mod tests {
               });
 
         // empty db => no last
-        eval!("[[c = CURSOR] SET c CURSOR/LAST SOME?] READ",
+        eval!("[CURSOR 'c SET c CURSOR/LAST SOME?] READ",
               env,
               result,
               {
@@ -681,7 +681,7 @@ mod tests {
               });
 
         // next after last is none
-        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/LAST DROP c CURSOR/NEXT NONE?] READ",
+        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/LAST DROP c CURSOR/NEXT NONE?] READ",
               env,
               result,
               {
@@ -689,7 +689,7 @@ mod tests {
                   assert_eq!(env.pop(), None);
               });
 
-        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC [c = CURSOR] SET c CURSOR/LAST UNWRAP] WRITE",
+        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC CURSOR 'c SET c CURSOR/LAST UNWRAP] WRITE",
               env,
               result,
               {
@@ -705,7 +705,7 @@ mod tests {
         eval!("CURSOR/SEEK", env, result, {
              assert!(result.is_err());
         });
-        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC COMMIT] WRITE [[c = CURSOR] SET c \"Hallo\" CURSOR/SEEK UNWRAP] READ",
+        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC COMMIT] WRITE [CURSOR 'c SET c \"Hallo\" CURSOR/SEEK UNWRAP] READ",
               env,
               result,
               {
@@ -714,7 +714,7 @@ mod tests {
                   assert_eq!(env.pop(), None);
               });
 
-        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC [c = CURSOR] SET c \"Hallo\" CURSOR/SEEK UNWRAP] WRITE",
+        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC CURSOR 'c SET c \"Hallo\" CURSOR/SEEK UNWRAP] WRITE",
               env,
               result,
               {
@@ -729,7 +729,7 @@ mod tests {
         eval!("CURSOR/PREV", env, result, {
              assert!(result.is_err());
         });
-        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST UNWRAP c CURSOR/NEXT UNWRAP c CURSOR/PREV UNWRAP] READ",
+        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST UNWRAP c CURSOR/NEXT UNWRAP c CURSOR/PREV UNWRAP] READ",
               env,
               result,
               {
@@ -741,7 +741,7 @@ mod tests {
                   assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("\"Goodbye\""));
                   assert_eq!(env.pop(), None);
               });
-        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC [c = CURSOR] SET c CURSOR/FIRST UNWRAP c CURSOR/NEXT UNWRAP c CURSOR/PREV UNWRAP] WRITE",
+        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC CURSOR 'c SET c CURSOR/FIRST UNWRAP c CURSOR/NEXT UNWRAP c CURSOR/PREV UNWRAP] WRITE",
               env,
               result,
               {
@@ -754,7 +754,7 @@ mod tests {
                   assert_eq!(env.pop(), None);
               });
         // prev before first is none
-        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC COMMIT] WRITE [[c = CURSOR] SET c CURSOR/FIRST DROP c CURSOR/PREV NONE?] READ",
+        eval!("[\"Hello\" \"world\" ASSOC \"Goodbye\" \"world\" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST DROP c CURSOR/PREV NONE?] READ",
               env,
               result,
               {
@@ -802,7 +802,7 @@ mod tests {
             let handle = scope.spawn(move || {
                 vm.run();
             });
-            let script = parse("[pair : HLC \"Hello\"] SET [pair] 1000 TIMES [[ASSOC COMMIT] WRITE] 1000 TIMES").unwrap();
+            let script = parse("[HLC \"Hello\"] 1000 TIMES [[ASSOC COMMIT] WRITE] 1000 TIMES").unwrap();
             let sender_ = sender.clone();
             b.iter(move || {
                 let (callback, receiver) = mpsc::channel::<ResponseMessage>();


### PR DESCRIPTION
The problem with SET syntax is that it is quite irregular (SET has to look into
the supplied closure) and therefore composes very poorly.

For example, one can't supply a value and a name separately to SET through the
stack. The values have to be wrapped in a very particular
way.

Solution: split SET into SET and DEF and, most importantly,
introduce composable syntax by leveraging newly introduced `'WORD`
text form syntax that encodes the word into a binary format.

```
CURSOR 'c SET
[EQUALS?] 'equals? DEF
```