### PR TITLE
hardcoded Rust-type based errors are problematic

### DIFF
--- a/doc/script/2DROP.md
+++ b/doc/script/2DROP.md
@@ -12,7 +12,7 @@ None
 
 ## Errors
 
-EmptyStack error if there are less than two items available on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items available on the stack
 
 ## Examples
 

--- a/doc/script/2DUP.md
+++ b/doc/script/2DUP.md
@@ -12,7 +12,7 @@ None
 
 ## Errors
 
-EmptyStack error if there are less than two items available on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items available on the stack
 
 ## Examples
 

--- a/doc/script/AND.md
+++ b/doc/script/AND.md
@@ -13,7 +13,7 @@ None
 
 ## Errors
 
-InvalidValue error if the both values are not booleans.
+[InvalidValue](./ERRORS/InvalidValue.md) error if the both values are not booleans.
 
 ## Examples
 

--- a/doc/script/ASSOCP.md
+++ b/doc/script/ASSOCP.md
@@ -19,9 +19,9 @@ None
 
 ## Errors
 
-EmptyStack error if there are less than two items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
-NoTransaction error if there's no current read or write transaction
+[EmptyStack](./ERRORS/NoTransaction.md) error if there's no current read or write transaction
 
 ## Examples
 

--- a/doc/script/COMMIT.md
+++ b/doc/script/COMMIT.md
@@ -15,11 +15,11 @@ None
 
 ## Errors
 
-EmptyStack error if there are less than two items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
-NoTransaction error if there's no current write transaction
+[NoTransaction](./ERRORS/NoTransaction.md) error if there's no current write transaction
 
-DuplicateKey error if the key has been already used.
+[DuplicateKey](./ERRORS/DuplicateKey.md) error if the key has been already used.
 
 ## Examples
 

--- a/doc/script/CONCAT.md
+++ b/doc/script/CONCAT.md
@@ -13,7 +13,7 @@ Allocates for a result of concatenation
 
 ## Errors
 
-EmptyStack error if there are less than two items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
 ## Examples
 

--- a/doc/script/DOWHILE.md
+++ b/doc/script/DOWHILE.md
@@ -12,9 +12,9 @@ Runtime allocation for code generation
 
 ## Errors
 
-EmptyStack error if there are less than one item on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than one item on the stack
 
-InvalidValue error if the value being checked for truth is not a boolean.
+[InvalidValue](./ERRORS/InvalidValue.md) error if the value being checked for truth is not a boolean.
 
 ## Examples
 

--- a/doc/script/DROP.md
+++ b/doc/script/DROP.md
@@ -12,7 +12,7 @@ None
 
 ## Errors
 
-EmptyStack error if nothing is available on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if nothing is available on the stack
 
 ## Examples
 

--- a/doc/script/DUP.md
+++ b/doc/script/DUP.md
@@ -12,7 +12,7 @@ None
 
 ## Errors
 
-EmptyStack error if nothing is available on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if nothing is available on the stack
 
 ## Examples
 

--- a/doc/script/EQUALP.md
+++ b/doc/script/EQUALP.md
@@ -14,7 +14,7 @@ None
 
 ## Errors
 
-EmptyStack error if there are less than two items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
 ## Examples
 

--- a/doc/script/ERRORS/DECODING.md
+++ b/doc/script/ERRORS/DECODING.md
@@ -1,0 +1,11 @@
+# Decoding error
+
+An error occurred decoding a program
+
+## Code
+
+`5`
+
+## Details
+
+None

--- a/doc/script/ERRORS/DatabaseError.md
+++ b/doc/script/ERRORS/DatabaseError.md
@@ -1,0 +1,16 @@
+# Database error
+
+A error occurred in the database subsystem
+
+## Code
+
+`9`
+
+## Description
+
+The internal error code reported from the database
+subsystem.
+
+## Details
+
+None

--- a/doc/script/ERRORS/DuplicateKey.md
+++ b/doc/script/ERRORS/DuplicateKey.md
@@ -1,0 +1,11 @@
+# Duplicate Key
+
+A key with the same value already exists.
+
+## Code
+
+`6`
+
+## Details
+
+The key

--- a/doc/script/ERRORS/EmptyStack.md
+++ b/doc/script/ERRORS/EmptyStack.md
@@ -1,0 +1,12 @@
+# Empty stack
+
+Not enough elements were on the stack when an operation
+was run on it,
+
+## Code
+
+`4`
+
+## Details
+
+None

--- a/doc/script/ERRORS/InvalidValue.md
+++ b/doc/script/ERRORS/InvalidValue.md
@@ -1,0 +1,11 @@
+# Invalid value
+
+A value specified to another word is invalid.
+
+## Code
+
+`3`
+
+## Details
+
+The invalid value.

--- a/doc/script/ERRORS/NoTransaction.md
+++ b/doc/script/ERRORS/NoTransaction.md
@@ -1,0 +1,12 @@
+# No transaction
+
+An operation requiring a transaction was run while not
+in a transaction.
+
+## Code
+
+`8`
+
+## Details
+
+None

--- a/doc/script/ERRORS/UNKNOWN_KEY.md
+++ b/doc/script/ERRORS/UNKNOWN_KEY.md
@@ -1,0 +1,11 @@
+# Duplicate Key
+
+A key with that value does not exist
+
+## Code
+
+`7`
+
+## Details
+
+The key

--- a/doc/script/ERRORS/UNKNOWN_WORD.md
+++ b/doc/script/ERRORS/UNKNOWN_WORD.md
@@ -1,0 +1,11 @@
+# Unknown word
+
+A word that does not exist was used.
+
+## Code
+
+`2`
+
+## Details
+
+None

--- a/doc/script/EVAL.md
+++ b/doc/script/EVAL.md
@@ -14,7 +14,7 @@ during the runtime.
 
 ## Errors
 
-EmptyStack error if there is less than one item on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there is less than one item on the stack
 
 ## Examples
 

--- a/doc/script/GTP.md
+++ b/doc/script/GTP.md
@@ -14,7 +14,7 @@ None
 
 ## Errors
 
-EmptyStack error if there are less than two items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
 ## Examples
 

--- a/doc/script/HLC/GTP.md
+++ b/doc/script/HLC/GTP.md
@@ -14,7 +14,7 @@ None
 
 ## Errors
 
-EmptyStack error if there are less than two items on the stack
+[EmptyStack](../ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
 It will fail if any of the top two items is not an HLC timestamp.
 

--- a/doc/script/HLC/LTP.md
+++ b/doc/script/HLC/LTP.md
@@ -14,7 +14,7 @@ None
 
 ## Errors
 
-EmptyStack error if there are less than two items on the stack
+[EmptyStack](../ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
 It will fail if any of the top two items is not an HLC timestamp.
 

--- a/doc/script/HLC/TICK.md
+++ b/doc/script/HLC/TICK.md
@@ -15,7 +15,7 @@ Allocates for the new timestamp to be pushed on stack.
 
 ## Errors
 
-EmptyStack error if there are less than one item on the stack
+[EmptyStack](../ERRORS/EmptyStack.md) error if there are less than one item on the stack
 
 It will fail if the item is not an HLC timestamp.
 

--- a/doc/script/IF.md
+++ b/doc/script/IF.md
@@ -21,7 +21,9 @@ None
 
 ## Errors
 
-InvalidValue error if the value being checked for truth is not a boolean.
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items on the stack
+
+[InvalidValue](./ERRORS/InvalidValue.md) error if the value being checked for truth is not a boolean.
 
 ## Examples
 

--- a/doc/script/IFELSE.md
+++ b/doc/script/IFELSE.md
@@ -23,7 +23,9 @@ None
 
 ## Errors
 
-InvalidValue error if the value being checked for truth is not a boolean.
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than three items on the stack
+
+[InvalidValue](./ERRORS/InvalidValue.md) error if the value being checked for truth is not a boolean.
 
 ## Examples
 

--- a/doc/script/LENGTH.md
+++ b/doc/script/LENGTH.md
@@ -15,7 +15,7 @@ Allocates for the result of the item size calculation
 
 ## Errors
 
-EmptyStack error if there are no items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are no items on the stack
 
 ## Examples
 

--- a/doc/script/LTP.md
+++ b/doc/script/LTP.md
@@ -14,7 +14,7 @@ None
 
 ## Errors
 
-EmptyStack error if there are less than two items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
 ## Examples
 

--- a/doc/script/NONEP.md
+++ b/doc/script/NONEP.md
@@ -17,7 +17,7 @@ None
 
 ## Errors
 
-EmptyStack error if there is less than one items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there is less than one items on the stack
 
 ## Examples
 

--- a/doc/script/NOT.md
+++ b/doc/script/NOT.md
@@ -14,7 +14,9 @@ None
 
 ## Errors
 
-InvalidValue error if the value being negated is not a boolean.
+[InvalidValue](./ERRORS/InvalidValue.md) error if the value being negated is not a boolean.
+
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
 ## Examples
 

--- a/doc/script/OR.md
+++ b/doc/script/OR.md
@@ -13,7 +13,9 @@ None
 
 ## Errors
 
-InvalidValue error if the both values are not booleans.
+[InvalidValue](./ERRORS/InvalidValue.md) error if the both values are not booleans.
+
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
 ## Examples
 

--- a/doc/script/OVER.md
+++ b/doc/script/OVER.md
@@ -12,7 +12,7 @@ None
 
 ## Errors
 
-EmptyStack error if there are less than two items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
 ## Examples
 

--- a/doc/script/READ.md
+++ b/doc/script/READ.md
@@ -17,9 +17,9 @@ marker word.
 
 ## Errors
 
-EmptyStack error if stack is less than two items on the stack.
+[EmptyStack](./ERRORS/EmptyStack.md) error if stack is less than two items on the stack.
 
-DatabaseError error if there's a problem with underlying storage.
+[DatabaseError](./ERRORS/DatabaseError.md) error if there's a problem with underlying storage.
 
 
 ## Examples

--- a/doc/script/RETR.md
+++ b/doc/script/RETR.md
@@ -17,9 +17,9 @@ None
 
 ## Errors
 
-EmptyStack error if there are less than two items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
-NoTransaction error if there's no current write transaction
+[NoTransaction](./ERRORS/NoTransaction.md) error if there's no current write transaction
 
 UnknownKey error if there is no such key. See [ASSOC?](ASSOCP.md)
 for mediating this problem

--- a/doc/script/ROT.md
+++ b/doc/script/ROT.md
@@ -12,7 +12,7 @@ None
 
 ## Errors
 
-EmptyStack error if there are less than three items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than three items on the stack
 
 ## Examples
 

--- a/doc/script/SEND.md
+++ b/doc/script/SEND.md
@@ -17,7 +17,7 @@ Allocates for sending data copies.
 
 ## Errors
 
-EmptyStack error if stack is less than two items on the stack.
+[EmptyStack](./ERRORS/EmptyStack.md) error if stack is less than two items on the stack.
 
 
 ## Examples

--- a/doc/script/SET.md
+++ b/doc/script/SET.md
@@ -42,7 +42,7 @@ The second (immediate evaluation) form allocates runtime memory
 
 ## Errors
 
-EmptyStack error if there are less than two items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
 It will error if the format of the closure is incorrect
 

--- a/doc/script/SLICE.md
+++ b/doc/script/SLICE.md
@@ -16,13 +16,13 @@ array is zero-copy.
 
 ## Errors
 
-EmptyStack error if there are less than three items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than three items on the stack
 
-InvalidValue error if `start` is larger than data length.
+[InvalidValue](./ERRORS/InvalidValue.md) error if `start` is larger than data length.
 
-InvalidValue error if `start` is lesser than `end`.
+[InvalidValue](./ERRORS/InvalidValue.md) error if `start` is lesser than `end`.
 
-InvalidValue error if `end` is larger than data length.
+[InvalidValue](./ERRORS/InvalidValue.md) error if `end` is larger than data length.
  
 
 ## Examples

--- a/doc/script/SOMEP.md
+++ b/doc/script/SOMEP.md
@@ -17,7 +17,7 @@ None
 
 ## Errors
 
-EmptyStack error if there is less than one items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there is less than one items on the stack
 
 ## Examples
 

--- a/doc/script/SWAP.md
+++ b/doc/script/SWAP.md
@@ -12,7 +12,7 @@ None
 
 ## Errors
 
-EmptyStack error if there are less than two items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than two items on the stack
 
 ## Examples
 

--- a/doc/script/TIMES.md
+++ b/doc/script/TIMES.md
@@ -13,7 +13,7 @@ Allocates for recursion during runtime.
 
 ## Errors
 
-EmptyStack error if there is less than two items on the stack
+[EmptyStack](./ERRORS/EmptyStack.md) error if there is less than two items on the stack
 
 ## Examples
 

--- a/doc/script/UNWRAP.md
+++ b/doc/script/UNWRAP.md
@@ -20,9 +20,9 @@ Runtime allocation during parsing
 
 ## Errors
 
-EmptyStack error if there is less than one item on the stack
+[DatabaseError](./ERRORS/DatabaseError.md) error if there is less than one item on the stack
 
-InvalidValue error if there are words in the item
+[InvalidValue](./ERRORS/InvalidValue.md) error if there are words in the item
 
 
 ## Examples

--- a/doc/script/WRITE.md
+++ b/doc/script/WRITE.md
@@ -19,9 +19,9 @@ marker word.
 
 ## Errors
 
-EmptyStack error if stack is less than two items on the stack.
+[EmptyStack](./ERRORS/EmptyStack.md) error if stack is less than two items on the stack.
 
-DatabaseError error if there's a problem with underlying storage.
+[DatabaseError](./ERRORS/DatabaseError.md) error if there's a problem with underlying storage.
 
 
 ## Examples

--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -89,6 +89,14 @@ macro_rules! stack_pop {
     }
 }
 
+macro_rules! word_is {
+    ($env: expr, $word: expr, $exp: expr) => {
+        if $word != $exp {
+            return Err(($env, Error::UnknownWord))
+        }
+    };
+}
+
 #[cfg(test)]
 macro_rules! eval {
         ($script: expr, $env: ident, $expr: expr) => {

--- a/src/script/timestamp_hlc.rs
+++ b/src/script/timestamp_hlc.rs
@@ -15,13 +15,13 @@ word!(HLC_TICK, b"\x88HLC/TICK");
 word!(HLC_LTP, b"\x87HLC/LT?");
 word!(HLC_GTP, b"\x87HLC/GT?");
 
-use super::{Env, EnvId, PassResult, Error, STACK_TRUE, STACK_FALSE};
+use super::{Env, EnvId, PassResult, Error, STACK_TRUE, STACK_FALSE, ERROR_EMPTY_STACK,
+            ERROR_INVALID_VALUE, offset_by_size};
 use timestamp;
 
 use hlc;
 use std::marker::PhantomData;
 use byteorder::{BigEndian, WriteBytesExt};
-
 
 pub struct Handler<'a> {
     phantom: PhantomData<&'a ()>
@@ -56,7 +56,7 @@ impl<'a> Handler<'a> {
             let b = env.pop();
 
             if a.is_none() || b.is_none() {
-                return Err((env, Error::EmptyStack));
+                return Err((env, error_empty_stack!()));
             }
 
             let mut a1 = a.unwrap();
@@ -65,8 +65,12 @@ impl<'a> Handler<'a> {
             let t1_ = hlc::Timestamp::<hlc::WallT>::read_bytes(&mut b1);
             let t2_ = hlc::Timestamp::<hlc::WallT>::read_bytes(&mut a1);
 
-            if t1_.is_err() || t2_.is_err() {
-                return Err((env, Error::InvalidValue))
+            if t1_.is_err() {
+                return Err((env, error_invalid_value!(b1)))
+            }
+
+            if t2_.is_err() {
+                return Err((env, error_invalid_value!(a1)))
             }
 
             let t1 = t1_.unwrap();
@@ -91,7 +95,7 @@ impl<'a> Handler<'a> {
             let b = env.pop();
 
             if a.is_none() || b.is_none() {
-                return Err((env, Error::EmptyStack));
+                return Err((env, error_empty_stack!()));
             }
 
             let mut a1 = a.unwrap();
@@ -100,8 +104,12 @@ impl<'a> Handler<'a> {
             let t1_ = hlc::Timestamp::<hlc::WallT>::read_bytes(&mut b1);
             let t2_ = hlc::Timestamp::<hlc::WallT>::read_bytes(&mut a1);
 
-            if t1_.is_err() || t2_.is_err() {
-                return Err((env, Error::InvalidValue))
+            if t1_.is_err() {
+                return Err((env, error_invalid_value!(b1)))
+            }
+
+            if t2_.is_err() {
+                return Err((env, error_invalid_value!(a1)))
             }
 
             let t1 = t1_.unwrap();
@@ -125,7 +133,7 @@ impl<'a> Handler<'a> {
             let a = env.pop();
 
             if a.is_none() {
-                return Err((env, Error::EmptyStack));
+                return Err((env, error_empty_stack!()));
             }
 
             let mut a1 = a.unwrap();
@@ -133,7 +141,7 @@ impl<'a> Handler<'a> {
             let t1_ = hlc::Timestamp::<hlc::WallT>::read_bytes(&mut a1);
 
             if t1_.is_err() {
-                return Err((env, Error::InvalidValue))
+                return Err((env, error_invalid_value!(a1)))
             }
 
             let mut t1 = t1_.unwrap();
@@ -159,7 +167,7 @@ impl<'a> Handler<'a> {
             let a = env.pop();
 
             if a.is_none() {
-                return Err((env, Error::EmptyStack));
+                return Err((env, error_empty_stack!()));
             }
 
             let mut a1 = a.unwrap();
@@ -167,7 +175,7 @@ impl<'a> Handler<'a> {
             let t1_ = hlc::Timestamp::<hlc::WallT>::read_bytes(&mut a1);
 
             if t1_.is_err() {
-                return Err((env, Error::InvalidValue))
+                return Err((env, error_invalid_value!(a1)))
             }
 
             let t1 = t1_.unwrap();


### PR DESCRIPTION
 Problem: When errors happen in PumpkinDB, the
client cannot simply parse them as PumpkinScript
but has to parse them as the string representation
of Rust errors.

Solution: Introduce a new PumpkinScript error
message.