### PR TITLE
Problem: unable to capture errors

### DIFF
--- a/doc/script/TRY.md
+++ b/doc/script/TRY.md
@@ -1,0 +1,36 @@
+# TRY
+
+Takes the topmost item and safely evaluates it as a PumpkinScript
+program on the current stack
+
+Input stack: `code`
+Output stack: `[]` or `[description details code]` (error closure)
+
+`TRY` is a close relative of [EVAL](EVAL.md). It also evaluates
+the closure but will not fail the program if there was an error.
+Instead, it will push an error closure onto the stack. If no error
+occurred, `[]` (an empty closure) will be pushed onto the stack.
+
+## Allocation
+
+Allocates a copy of the code (this might change in the future)
+during the runtime. Allocates on program's heap when recovering
+from an error that occurred.
+
+## Errors
+
+[EmptyStack](./ERRORS/EmptyStack.md) error if there is less than one item on the stack
+
+## Examples
+
+```
+[DUP] TRY SOME? => 0x1
+[1 DUP] TRY SOME? => 0x1 0x1 0x0
+```
+
+## Tests
+
+```
+[DUP] TRY SOME? => 0x1
+[1 DUP] TRY SOME? => 0x1 0x1 0x0
+```


### PR DESCRIPTION
This prevents us from handling errors and doing something if they occur.

Solution: introduce TRY word that safely evaluates the closure and pushes an
error closure or an empty closure onto the stack.

While at it, I discovered that `error_program!` macro over-encoded closures
(because the errors are supposed to go on to the stack), so it led to something
like this:

```
[DUP] TRY UNWRAP UNWRAP
0x456D70747920737461636B 0x 0x4
```

(while it should be just one UNWRAP, of course)

So I fixed that and `assert_error!` macro as well.