### PR TITLE
Problem: heap-based allocation is potentially dangerous

### DIFF
--- a/src/crates.rs
+++ b/src/crates.rs
@@ -3,8 +3,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-extern crate alloc;
-
 #[cfg(test)]
 #[macro_use]
 extern crate matches;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@
 #![feature(slice_patterns, advanced_slice_patterns)]
 #![cfg_attr(test, feature(test))]
 
-#![feature(alloc, heap_api)]
-
 include!("crates.rs");
 
 pub mod script;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@
 
 include!("crates.rs");
 
+extern crate alloc;
+
 pub mod script;
 pub mod server;
 pub mod timestamp;


### PR DESCRIPTION
One requires very good amount of precision to get it right.
As a matter of fact I am seeing some data abberrations right now,
like this:

```
PumpkinDB> ["Hello"] 500 TIMES
"Hello" "Hello" "Hello" "Hello" "Hello" "Hello"
"Hello" "Hello" "Hello" "Hello" "Hello" "Hello" "Hello" "Hello" "Hello" "Hello"
"Hello" 0xd9a12e0101 "Hello" "Hello" "Hello" "Hello" "Hello" "Hello" "Hello"
"Hello" 0x0000000959 0x2e01010000 "Hello" "Hello" "Hello" "Hello" "Hello"
"Hello" "Hello" "Hello" "Hello" "Hello" "Hello" "Hello" "Hello" "Hello" "Hello"
"Hello" "Hello" "Hello" "Hello" "Hello" "Hello" "Hello" "Hello" "Hello"
0x009dd92d01 0x0100000005 0x0000000000 0x0000cd792e 0x0101000000 "Hello"
"Hello" “Hello”...
```

Solution: use Vec-based heap instead