### PR TITLE
Problem: implementing words without subwords is difficult

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ matrix:
     - rust: stable 
 script:
   - cargo build --verbose
+  - cargo build --features="experimental" --verbose
   - make test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,5 @@ crossbeam = "0.2.10"
 
 [features]
 travis = []
+experimental = ["scoped_dictionary"]
+scoped_dictionary = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,5 @@ tempdir = "0.3.5"
 crossbeam = "0.2.10"
 
 [features]
-travis = []
 experimental = ["scoped_dictionary"]
 scoped_dictionary = []

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 
 test:
-	cargo test --features=travis -- --nocapture
+	cargo test -- --nocapture
 	cargo test --features="experimental" -- --nocapture
 	cargo test --features="scoped_dictionary" -- --nocapture

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY : test
+.PHONY: test
 
 test:
-	cargo test --verbose --features=travis
+	cargo test --features=travis -- --nocapture
+	cargo test --features="experimental" -- --nocapture
+	cargo test --features="scoped_dictionary" -- --nocapture

--- a/doc/FEATURES.md
+++ b/doc/FEATURES.md
@@ -1,0 +1,23 @@
+# Experimental Features
+
+PumpkinDB is new and many (experimental )features are being hashed out. Instead of
+these features sitting in their own branches or Pull Requests, we decided to encourage
+broader experimentation.
+
+By default, no experimental features are enabled in a build. However,
+one can enable all experimental features by building with an appropriate flag:
+
+```
+$ cargo build --features="experimental"
+```
+
+Or supply a space-delimited list of individual features of interest.
+
+Once a feature is considered to be stable enough, the feature can be
+first promoted to the `default` feature set and once fully graduated
+(after a period of additional testing received through the inclusion
+in`default`), the feature gate can be dropped.
+
+## Current experimental features
+
+* `scoped_dictionary` ([issue #71](https://github.com/PumpkinDB/PumpkinDB/issues/71))

--- a/doc/script/DEF.md
+++ b/doc/script/DEF.md
@@ -16,6 +16,10 @@ remainder.
 `DEF` will put the second topmost item off the stack (`c`) into the
 word referenced by top item (`w`)
 
+If the `scoped_dictionary` feature has been enabled, the definition
+is valid for the scope of the closure, or the rest of the program if
+used outside of a closure. Otherwise, the definition is valid for the
+rest of the program, unless overridden.
 
 ## Allocation
 

--- a/doc/script/DEF.md
+++ b/doc/script/DEF.md
@@ -16,11 +16,6 @@ remainder.
 `DEF` will put the second topmost item off the stack (`c`) into the
 word referenced by top item (`w`)
 
-If the `scoped_dictionary` feature has been enabled, the definition
-is valid for the scope of the closure, or the rest of the program if
-used outside of a closure. Otherwise, the definition is valid for the
-rest of the program, unless overridden.
-
 ## Allocation
 
 None.

--- a/doc/script/EVAL/SCOPED.md
+++ b/doc/script/EVAL/SCOPED.md
@@ -1,0 +1,37 @@
+# EVAL/SCOPED
+
+## Experimental feature: `scoped_dictionary`
+
+Takes the topmost item and evaluates it as a PumpkinScript
+program on the current stack with a clone of the dictionary
+
+Input stack: `code`
+
+Output stack: result of `code` evaluation
+
+`EVAL/SCOPED` is a sister version of [EVAL](../EVAL.md) with
+one important distinction: all new words defined inside 
+(or updated values for previously defined ones) within this
+evaluation (using [SET](../SET.md) and [DEF](../DEF.md)) will be
+gone after the evaluation.  
+ 
+## Allocation
+
+Allocates a copy of the code (this might change in the future)
+during the runtime.
+
+## Errors
+
+[EmptyStack](./ERRORS/EmptyStack.md) error if there is less than one item on the stack
+
+## Examples
+
+```
+1 'val SET [2 'val SET val] EVAL/SCOPED val => 2 1
+```
+
+## Tests
+
+```
+1 'val SET [2 'val SET val] EVAL/SCOPED val => 2 1
+```

--- a/doc/script/SET.md
+++ b/doc/script/SET.md
@@ -16,11 +16,6 @@ remainder.
 `SET` will put the second topmost item off the stack (`v`) into the
 word referenced by top item (`w`)
 
-If the `scoped_dictionary` feature has been enabled, the definition
-is valid for the scope of the closure, or the rest of the program if
-used outside of a closure. Otherwise, the definition is valid for the
-rest of the program, unless overridden.
-
 ## Allocation
 
 Allocates on the heap for the binary form definition.

--- a/doc/script/SET.md
+++ b/doc/script/SET.md
@@ -16,7 +16,10 @@ remainder.
 `SET` will put the second topmost item off the stack (`v`) into the
 word referenced by top item (`w`)
 
-
+If the `scoped_dictionary` feature has been enabled, the definition
+is valid for the scope of the closure, or the rest of the program if
+used outside of a closure. Otherwise, the definition is valid for the
+rest of the program, unless overridden.
 
 ## Allocation
 

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -118,6 +118,8 @@ word!(UINT_ADD, (a, b => c), b"\x88UINT/ADD");
 word!(UINT_SUB, (a, b => c), b"\x88UINT/SUB");
 
 // Category: Control flow
+#[cfg(feature = "scoped_dictionary")]
+word!(SCOPE_END, b"\x80\x81/"); // internal word
 word!(DOWHILE, b"\x87DOWHILE");
 word!(TIMES, b"\x85TIMES");
 word!(EVAL, b"\x84EVAL");
@@ -241,6 +243,9 @@ pub struct Env<'a> {
     stack: Vec<&'a [u8]>,
     stack_size: usize,
     heap: EnvHeap,
+    #[cfg(feature = "scoped_dictionary")]
+    dictionary: Vec<BTreeMap<&'a [u8], &'a [u8]>>,
+    #[cfg(not(feature = "scoped_dictionary"))]
     dictionary: BTreeMap<&'a [u8], &'a [u8]>,
     // current TRY status
     tracking_errors: usize,
@@ -277,11 +282,15 @@ impl<'a> Env<'a> {
     /// This function is useful for working with result stacks received from
     /// [VM](struct.VM.html)
     pub fn new_with_stack(stack: Vec<&'a [u8]>, stack_size: usize) -> Result<Self, Error> {
+        #[cfg(feature = "scoped_dictionary")]
+        let dictionary = vec![BTreeMap::new()];
+        #[cfg(not(feature = "scoped_dictionary"))]
+        let dictionary = BTreeMap::new();
         Ok(Env {
             stack: stack,
             stack_size: stack_size,
             heap: EnvHeap::new(HEAP_SIZE),
-            dictionary: BTreeMap::new(),
+            dictionary: dictionary,
             tracking_errors: 0,
             aborting_try: Vec::new(),
             send_ack: None
@@ -334,7 +343,25 @@ impl<'a> Env<'a> {
     pub fn alloc(&mut self, len: usize) -> Result<&'a mut [u8], Error> {
         Ok(unsafe { mem::transmute::<& mut [u8], &'a mut [u8]>(self.heap.alloc(len)) })
     }
+
+
+    #[cfg(feature = "scoped_dictionary")]
+    pub fn push_dictionary(&mut self) {
+        let dict = self.dictionary.pop().unwrap();
+        let new_dict = dict.clone();
+        self.dictionary.push(dict);
+        self.dictionary.push(new_dict);
+    }
+
+    #[cfg(feature = "scoped_dictionary")]
+    pub fn pop_dictionary(&mut self) {
+        self.dictionary.pop();
+        if self.dictionary.len() == 0 {
+            self.dictionary.push(BTreeMap::new());
+        }
+    }
 }
+
 
 use nom;
 
@@ -534,6 +561,7 @@ impl<'a> VM<'a> {
         }
     }
 
+    #[allow(unused_mut)]
     fn pass(&mut self, mut env: Env<'a>, program: &mut Vec<u8>, pid: EnvId) -> PassResult<'a> {
         // Check if this Env has a pending SEND
         match mem::replace(&mut env.send_ack, None) {
@@ -592,6 +620,7 @@ impl<'a> VM<'a> {
                            self => handle_length,
                            self => handle_dowhile,
                            self => handle_times,
+                           self => handle_scope_end,
                            self => handle_eval,
                            self => handle_eval_validp,
                            self => handle_try,
@@ -632,7 +661,11 @@ impl<'a> VM<'a> {
                               let (env_, rest) = match res {
                                   (env_, Some(mut vec)) => {
                                       let mut rest_0 = program.split_off(word.len());
+                                      #[cfg(feature = "scoped_dictionary")]
+                                      vec.extend_from_slice(SCOPE_END);
                                       vec.append(&mut rest_0);
+                                      #[cfg(feature = "scoped_dictionary")]
+                                      env_.push_dictionary();
                                       (env_, vec)
                                   }
                                   (env_, None) => (env_, program.split_off(word.len())),
@@ -971,6 +1004,23 @@ impl<'a> VM<'a> {
         Ok((env, None))
     }
 
+
+
+    #[inline]
+    #[cfg(feature = "scoped_dictionary")]
+    fn handle_scope_end(&mut self, mut env: Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
+        word_is!(env, word, SCOPE_END);
+        env.pop_dictionary();
+        Ok((env, None))
+    }
+
+
+    #[inline]
+    #[cfg(not(feature = "scoped_dictionary"))]
+    fn handle_scope_end(&mut self, env: Env<'a>, _: &'a [u8], _: EnvId) -> PassResult<'a> {
+        Err((env, Error::UnknownWord))
+    }
+
     #[inline]
     fn handle_uint_add(&mut self, mut env: Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
         word_is!(env, word, UINT_ADD);
@@ -1182,6 +1232,13 @@ impl<'a> VM<'a> {
                             slice[offset] = *b;
                             offset += 1;
                         }
+                        #[cfg(feature = "scoped_dictionary")]
+                        {
+                            let mut dict = env.dictionary.pop().unwrap();
+                            dict.insert(word, slice);
+                            env.dictionary.push(dict);
+                        }
+                        #[cfg(not(feature = "scoped_dictionary"))]
                         env.dictionary.insert(word, slice);
                         Ok((env, None))
                     }
@@ -1199,6 +1256,13 @@ impl<'a> VM<'a> {
         assert_decodable!(env, value);
         match binparser::word(word) {
             nom::IResult::Done(_, _) => {
+                #[cfg(feature = "scoped_dictionary")]
+                {
+                    let mut dict = env.dictionary.pop().unwrap();
+                    dict.insert(word, value);
+                    env.dictionary.push(dict);
+                }
+                #[cfg(not(feature = "scoped_dictionary"))]
                 env.dictionary.insert(word, value);
                 Ok((env, None))
             },
@@ -1221,6 +1285,25 @@ impl<'a> VM<'a> {
     }
 
     #[inline]
+    #[cfg(feature = "scoped_dictionary")]
+    fn handle_dictionary(&mut self, mut env: Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
+        let dict = env.dictionary.pop().unwrap();
+        if dict.contains_key(word) {
+            let mut vec = Vec::new();
+            {
+                let def = dict.get(word).unwrap();
+                vec.extend_from_slice(def);
+            }
+            env.dictionary.push(dict);
+            Ok((env, Some(vec)))
+        } else {
+            env.dictionary.push(dict);
+            Err((env, Error::UnknownWord))
+        }
+    }
+
+    #[inline]
+    #[cfg(not(feature = "scoped_dictionary"))]
     fn handle_dictionary(&mut self, env: Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
         if env.dictionary.contains_key(word) {
             let mut vec = Vec::new();
@@ -1754,6 +1837,34 @@ mod tests {
             assert_error!(result, "[\"Empty stack\" [] 4]");
         });
 
+    }
+
+    #[test]
+    #[cfg(feature = "scoped_dictionary")]
+    fn dictionary_scoping() {
+        eval!("[2 'val SET val] EVAL val", env, result, {
+            assert_error!(result, "[\"Unknown word: val\" [val] 2]");
+        });
+
+        eval!("1 'val SET [2 'val SET val] EVAL val", env, result, {
+            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x01"));
+            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x02"));
+            assert_eq!(env.pop(), None);
+        });
+        eval!("1 'val SET [2 'val SET val] TRY val", env, result, {
+            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x01"));
+            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("[]"));
+            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x02"));
+            assert_eq!(env.pop(), None);
+        });
+
+        eval!("1 'val SET [2 'val SET val] 3 TIMES val", env, result, {
+            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x01"));
+            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x02"));
+            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x02"));
+            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x02"));
+            assert_eq!(env.pop(), None);
+        });
     }
 
     #[test]


### PR DESCRIPTION
Technically speaking, loaded words *can* define their own
words but they will leak into the remainder of the program,
which less than ideal.

Using stack alone requires a significant amount of juggling
that makes writing code incredibly frustrating. I personally
believe that the value of stack based programming languages
is in concatenative abilities (composition via stack), not
just being able to do everything by juggling items in the
stack.

Solution: make all SETs and DEFs done within any closure
local to that closure.

This means that if eventually we'll need to do code injection
that's not injecting what effectively amounts to closures,
we'll need to have a separate pass result type that can
indicate that.