### PR TITLE
Problem: write_1000_kv_pairs_in_isolated_txns excluded from Travis CI

### DIFF
--- a/src/script/storage.rs
+++ b/src/script/storage.rs
@@ -776,10 +776,6 @@ mod tests {
     use test::Bencher;
 
     #[bench]
-    // This test, even when executed under `cargo test`,
-    // is hanging on Travis CI. Unable to figure it out now,
-    // disabling it.
-    #[cfg(not(feature = "travis"))]
     fn write_1000_kv_pairs_in_isolated_txns(b: &mut Bencher) {
         let path = "pumpkindb-bench-write_1000_kv_pairs_in_isolated_txns";
         fs::create_dir_all(path).expect("can't create directory");


### PR DESCRIPTION
It was hanging there for whatever reason.

Solution: with recent changes in allocation, this should work,
so lets re-enable the test on Travis. Keep the feature gate, though.