### PR TITLE
Problem: failing tests hang `cargo tests`

### DIFF
--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -291,22 +291,25 @@ macro_rules! eval {
                 match receiver.recv() {
                    Ok(ResponseMessage::EnvTerminated(_, stack, stack_size)) => {
                       let _ = sender.send(RequestMessage::Shutdown);
+                      $publisher_accessor.shutdown();
                       let $result = Ok::<(), Error>(());
                       let mut $env = Env::new_with_stack(stack, stack_size).unwrap();
                       $expr;
                    }
                    Ok(ResponseMessage::EnvFailed(_, err, stack, stack_size)) => {
                       let _ = sender.send(RequestMessage::Shutdown);
+                      $publisher_accessor.shutdown();
                       let $result = Err::<(), Error>(err);
                       let mut $env = Env::new_with_stack(stack.unwrap(), stack_size.unwrap()).unwrap();
                       $expr;
                    }
                    Err(err) => {
+                      let _ = sender.send(RequestMessage::Shutdown);
+                      $publisher_accessor.shutdown();
                       panic!("recv error: {:?}", err);
                    }
                 }
                 let _ = handle.join();
-                $publisher_accessor.shutdown();
                 let _ = publisher_thread.join();
           });
         };


### PR DESCRIPTION
Solution: ensure we're always shutting down other
threads so that the test can finish