### PR TITLE
Problem: SEND implementation is blocking

### DIFF
--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -110,6 +110,12 @@ impl<T : Sized + Clone> PublisherAccessor<T> {
         let _ = r.recv();
     }
 
+    pub fn send_async(&self, topic: Topic, data: T) -> mpsc::Receiver<()> {
+        let (s, r) = mpsc::channel();
+        let _ = self.sender.send(PublisherMessage::Send(topic, data, s));
+        r
+    }
+
     /// Shutdown publisher
     pub fn shutdown(&self) {
         let _ = self.sender.send(PublisherMessage::Shutdown);

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -237,7 +237,8 @@ pub struct Env<'a> {
     dictionary: BTreeMap<&'a [u8], &'a [u8]>,
     // current TRY status
     tracking_errors: usize,
-    aborting_try: Vec<Error>
+    aborting_try: Vec<Error>,
+    send_ack: Option<mpsc::Receiver<()>>
 }
 
 impl<'a> std::fmt::Debug for Env<'a> {
@@ -275,7 +276,8 @@ impl<'a> Env<'a> {
             heap: EnvHeap::new(HEAP_SIZE),
             dictionary: BTreeMap::new(),
             tracking_errors: 0,
-            aborting_try: Vec::new()
+            aborting_try: Vec::new(),
+            send_ack: None
         })
     }
 
@@ -494,6 +496,10 @@ impl<'a> VM<'a> {
                 }
                 Ok(RequestMessage::RescheduleEnv(pid, mut program, env, chan)) => {
                     match self.pass(env, &mut program, pid.clone()) {
+                        Err((env, Error::Reschedule)) => {
+                            let _ = self.loopback
+                                .send(RequestMessage::RescheduleEnv(pid, program, env, chan));
+                        }
                         Err((env, err)) => {
                             let _ = chan.send(ResponseMessage::EnvFailed(pid,
                                                                          err,
@@ -516,6 +522,19 @@ impl<'a> VM<'a> {
     }
 
     fn pass(&mut self, mut env: Env<'a>, program: &mut Vec<u8>, pid: EnvId) -> PassResult<'a> {
+        // Check if this Env has a pending SEND
+        match mem::replace(&mut env.send_ack, None) {
+            None => (),
+            Some(rcvr) =>
+                match rcvr.try_recv() {
+                    Err(mpsc::TryRecvError::Empty) => {
+                        env.send_ack = Some(rcvr);
+                        return Err((env, Error::Reschedule))
+                    },
+                    Err(mpsc::TryRecvError::Disconnected) => (),
+                    Ok(()) => ()
+                }
+        }
         if program.len() == 0 {
             return Ok((env, None));
         }
@@ -1101,7 +1120,9 @@ impl<'a> VM<'a> {
         let topic = stack_pop!(env);
         let data = stack_pop!(env);
 
-        self.publisher.send(Vec::from(topic), Vec::from(data));
+        let receiver = self.publisher.send_async(Vec::from(topic), Vec::from(data));
+
+        env.send_ack = Some(receiver);
 
         Ok((env, None))
     }


### PR DESCRIPTION
Right now, because of how pubsub::PublisherAccessor.send is implemented, it'll
wait until the message has fully gone through, which will block the scheduler
until then.

This is, of course, unacceptable!

Solution: have a send_async that returns a receiver, if receiver's
try_recv on the next round is not yielding anything, keep rescheduling.

Fixes #75