### PR TITLE
Problem: evaluating invalid code trips up the scheduler

### DIFF
--- a/doc/script/DEF.md
+++ b/doc/script/DEF.md
@@ -25,6 +25,8 @@ None.
 
 EmptyStack error if there are less than two items on the stack
 
+[Decoding error](./ERRORS/DECODING.md) error if the code is undecodable.
+
 It will error if the format of the word is incorrect
 
 It may error if this word is a built-in word that was previously

--- a/doc/script/DOWHILE.md
+++ b/doc/script/DOWHILE.md
@@ -16,6 +16,8 @@ Runtime allocation for code generation
 
 [InvalidValue](./ERRORS/InvalidValue.md) error if the value being checked for truth is not a boolean.
 
+[Decoding error](./ERRORS/DECODING.md) error if the code is undecodable.
+
 ## Examples
 
 ```

--- a/doc/script/EVAL.md
+++ b/doc/script/EVAL.md
@@ -16,6 +16,8 @@ during the runtime.
 
 [EmptyStack](./ERRORS/EmptyStack.md) error if there is less than one item on the stack
 
+[Decoding error](./ERRORS/DECODING.md) error if the code is undecodable.
+
 ## Examples
 
 ```

--- a/doc/script/EVAL/VALIDP.md
+++ b/doc/script/EVAL/VALIDP.md
@@ -1,0 +1,40 @@
+# EVAL/VALID?
+
+Assesses validity of the code from the perspective of decoding
+
+Input stack: `code`
+
+Output stack: `1` or `0`
+
+`EVAL/VALID?` will only verify if PumpkinDB will be able to
+interpret the code. However, it won't assess any other properties
+pertaining to its validity.
+
+Generally speaking, this word is only reserved for
+some special cases as `EVAL` will fail upon trying to
+evaluate incorrect code anyway.
+
+## Allocation
+
+Allocates for parsing the binary representation of the program.
+
+## Errors
+
+[EmptyStack](./ERRORS/EmptyStack.md) error if there is less than
+one item on the stack
+
+## Examples
+
+```
+1 EVAL/VALID? => 0x00
+'DUP EVAL/VALID? => 0x01
+[1 DUP] EVAL/VALID? => 0x01
+```
+
+## Tests
+
+```
+1 EVAL/VALID? => 0x00
+'DUP EVAL/VALID? => 0x01
+[1 DUP] EVAL/VALID? => 0x01
+```

--- a/doc/script/IF.md
+++ b/doc/script/IF.md
@@ -25,6 +25,8 @@ None
 
 [InvalidValue](./ERRORS/InvalidValue.md) error if the value being checked for truth is not a boolean.
 
+[Decoding error](./ERRORS/DECODING.md) error if the code is undecodable.
+
 ## Examples
 
 ```

--- a/doc/script/IFELSE.md
+++ b/doc/script/IFELSE.md
@@ -27,6 +27,8 @@ None
 
 [InvalidValue](./ERRORS/InvalidValue.md) error if the value being checked for truth is not a boolean.
 
+[Decoding error](./ERRORS/DECODING.md) error if the code is undecodable.
+
 ## Examples
 
 ```

--- a/doc/script/READ.md
+++ b/doc/script/READ.md
@@ -21,6 +21,8 @@ marker word.
 
 [DatabaseError](./ERRORS/DatabaseError.md) error if there's a problem with underlying storage.
 
+[Decoding error](./ERRORS/DECODING.md) error if the code is undecodable.
+
 
 ## Examples
 

--- a/doc/script/TIMES.md
+++ b/doc/script/TIMES.md
@@ -15,6 +15,8 @@ Allocates for recursion during runtime.
 
 [EmptyStack](./ERRORS/EmptyStack.md) error if there is less than two items on the stack
 
+[Decoding error](./ERRORS/DECODING.md) error if the code is undecodable.
+
 ## Examples
 
 ```

--- a/doc/script/TRY.md
+++ b/doc/script/TRY.md
@@ -21,6 +21,8 @@ from an error that occurred.
 
 [EmptyStack](./ERRORS/EmptyStack.md) error if there is less than one item on the stack
 
+[Decoding error](./ERRORS/DECODING.md) error if the code is undecodable.
+
 ## Examples
 
 ```

--- a/doc/script/WRITE.md
+++ b/doc/script/WRITE.md
@@ -23,6 +23,7 @@ marker word.
 
 [DatabaseError](./ERRORS/DatabaseError.md) error if there's a problem with underlying storage.
 
+[Decoding error](./ERRORS/DECODING.md) error if the code is undecodable.
 
 ## Examples
 

--- a/src/script/binparser.rs
+++ b/src/script/binparser.rs
@@ -17,14 +17,13 @@ pub fn word_tag(i: &[u8]) -> IResult<&[u8], u8> {
     }
 }
 
-pub fn internal_word(i: &[u8]) -> IResult<&[u8], &[u8]> {
+pub fn internal_word_tag(i: &[u8]) -> IResult<&[u8], u8> {
     if i.len() < 2 {
-        IResult::Incomplete(Needed::Size(1))
-    } else if i[0] != 128 {
+        IResult::Incomplete(Needed::Size(2))
+    } else if i[0] != 128 || i[1] < 129 {
         IResult::Error(ErrorKind::Custom(128))
     } else {
-        IResult::Done(&i[(i[1] - 128 + 2) as usize..],
-                      &i[0..(i[1] - 128 + 2) as usize])
+        IResult::Done(&i[0..], i[1] - 128 + 2)
     }
 }
 
@@ -100,6 +99,7 @@ fn flatten_program(p: Vec<&[u8]>) -> Vec<u8> {
 named!(pub data_size<usize>, alt!(micro_length | byte_length | small_length | big_length));
 named!(pub data, length_bytes!(data_size));
 named!(pub word, length_bytes!(word_tag));
+named!(pub internal_word, length_bytes!(internal_word_tag));
 named!(pub word_or_internal_word, alt!(internal_word | word));
 named!(item, alt!(word | data));
 named!(split_code<Vec<u8>>, do_parse!(


### PR DESCRIPTION
If it can't understand how to proceed and how to find
TRY_END, then chances are, the client will never collect
the error.

Solution: harden all evaluation methods by checking decodability
of all the code being evaluated. Also, provide EVAL/VALID? to
let the end user verify whether the code can be decoded.