### PR TITLE
 Problem: Heap allocation constructs are too verbose

### DIFF
--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -268,6 +268,26 @@ macro_rules! write_size_header {
     }};
 }
 
+macro_rules! alloc_slice {
+    ($size: expr, $env: expr) => {{
+        let slice = $env.alloc($size);
+        if slice.is_err() {
+            return Err(($env, slice.unwrap_err()));
+        }
+        slice.unwrap()
+    }};
+}
+
+macro_rules! alloc_and_write {
+    ($bytes: expr, $env: expr) => {{
+        let slice = alloc_slice!($bytes.len(), $env);
+        for i in 0..$bytes.len() {
+            slice[i] = $bytes[i];
+        }
+        slice
+    }};
+}
+
 #[cfg(test)]
 macro_rules! eval {
         ($script: expr, $env: ident, $expr: expr) => {

--- a/src/script/timestamp_hlc.rs
+++ b/src/script/timestamp_hlc.rs
@@ -36,11 +36,7 @@ impl<'a> Handler<'a> {
     pub fn handle_hlc(&mut self, mut env: Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
         if word == HLC {
             let now = timestamp::hlc();
-            let slice0 = env.alloc(16);
-            if slice0.is_err() {
-                return Err((env, slice0.unwrap_err()));
-            }
-            let mut slice = slice0.unwrap();
+            let slice = alloc_slice!(16, env);
             let _ = now.write_bytes(&mut slice[0..]).unwrap();
             env.push(slice);
             Ok((env, None))
@@ -147,11 +143,7 @@ impl<'a> Handler<'a> {
             let mut t1 = t1_.unwrap();
             t1.count += 1;
 
-            let slice0 = env.alloc(16);
-            if slice0.is_err() {
-                return Err((env, slice0.unwrap_err()));
-            }
-            let slice = slice0.unwrap();
+            let slice = alloc_slice!(16, env);
             let _ = t1.write_bytes(&mut slice[0..]).unwrap();
             env.push(slice);
 
@@ -180,11 +172,7 @@ impl<'a> Handler<'a> {
 
             let t1 = t1_.unwrap();
 
-            let slice0 = env.alloc(4);
-            if slice0.is_err() {
-                return Err((env, slice0.unwrap_err()));
-            }
-            let slice = slice0.unwrap();
+            let slice = alloc_slice!(4, env);
             let _ = (&mut slice[0..]).write_u32::<BigEndian>(t1.count);
 
             env.push(slice);


### PR DESCRIPTION
Problem: Heap allocation constructs are too verbose

Solution: Introduce a alloc and alloc_write macro
to make it easier.


 #50 