### PR TITLE
Problem: copying to slices is usually a silly cycle

### DIFF
--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -281,9 +281,7 @@ macro_rules! alloc_slice {
 macro_rules! alloc_and_write {
     ($bytes: expr, $env: expr) => {{
         let slice = alloc_slice!($bytes.len(), $env);
-        for i in 0..$bytes.len() {
-            slice[i] = $bytes[i];
-        }
+        slice.copy_from_slice($bytes);
         slice
     }};
 }

--- a/src/script/storage.rs
+++ b/src/script/storage.rs
@@ -125,15 +125,11 @@ macro_rules! cursor_op {
                 let slice = alloc_slice!(sz, $env);
                 write_size_into_slice!(key.len(), &mut slice[offset..]);
                 offset += offset_by_size(key.len());
-                for i in 0..key.len() {
-                    slice[offset+i] = key[i];
-                }
+                slice[offset..offset + key.len()].copy_from_slice(key);
                 offset += key.len();
                 write_size_into_slice!(val.len(), &mut slice[offset..]);
                 offset += offset_by_size(val.len());
-                for i in 0..val.len() {
-                    slice[offset+i] = val[i];
-                }
+                slice[offset..offset + val.len()].copy_from_slice(val);
                 $env.push(slice);
            }
            // not found
@@ -389,7 +385,7 @@ impl<'a> Handler<'a> {
                     }
                     let _ = bytes.write_u64::<BigEndian>(id.offset);
                     self.cursors.insert((pid.clone(), bytes.clone()), (tx_type!(self, env), Handler::cast_away(cursor)));
-                    let slice = alloc_and_write!(bytes, env);
+                    let slice = alloc_and_write!(bytes.as_slice(), env);
                     env.push(slice);
                     Ok((env, None))
                 },


### PR DESCRIPTION
It's verbose, potentially slow and definitely error
prone as one might miscalculate

Solution: use `slice.copy_from_slice(src)` primitive.

One very good thing about it is that it forces to make
sure the sizing of both destination and source are equal,
because it will panic otherwise.

Fixes #58