### PR TITLE
Problem: error details are encoded incorrectly

### DIFF
--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -142,6 +142,10 @@ macro_rules! error_program {
         write_size_header!($desc, error);
         error.extend_from_slice($desc);
 
+        if $details.len() > 0 {
+            write_size!($details.len() + offset_by_size($details.len()), error);
+        }
+
         write_size_header!($details, error);
         error.extend_from_slice($details);
 
@@ -216,25 +220,11 @@ macro_rules! error_empty_stack {
     }}
 }
 
-macro_rules! error_invalid_value_word {
-    ($value: expr) => {{
-        error_program!(
-            "Invalid value".as_bytes(),
-            $value,
-            ERROR_INVALID_VALUE
-        )
-    }}
-}
-
 macro_rules! error_invalid_value {
     ($value: expr) => {{
-        let mut details = Vec::new();
-        write_size_header!($value, details);
-        details.extend_from_slice($value);
-
         error_program!(
             "Invalid value".as_bytes(),
-            &details,
+            &$value,
             ERROR_INVALID_VALUE
         )
     }}
@@ -262,8 +252,14 @@ macro_rules! error_unknown_word {
 
 macro_rules! write_size_header {
     ($bytes: expr, $vec: expr) => {{
-        let mut header = vec![0;offset_by_size($bytes.len())];
-        write_size_into_slice!($bytes.len(), header.as_mut_slice());
+        write_size!($bytes.len(), $vec);
+    }};
+}
+
+macro_rules! write_size {
+    ($size: expr, $vec: expr) => {{
+        let mut header = vec![0;offset_by_size($size)];
+        write_size_into_slice!($size, header.as_mut_slice());
         $vec.append(&mut header);
     }};
 }

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -1104,7 +1104,7 @@ impl<'a> VM<'a> {
                     current = rest
                 },
                 _ => {
-                    return Err((env, error_invalid_value_word!(current)))
+                    return Err((env, error_invalid_value!(current)))
                 }
             }
         }
@@ -1286,6 +1286,15 @@ mod tests {
     use pubsub;
 
     const _EMPTY: &'static [u8] = b"";
+
+    #[test]
+    fn error_macro() {
+        if let Error::ProgramError(err) = error_program!("Test".as_bytes(), "123".as_bytes(),b"\x01\x33") {
+            assert_eq!(err, parsed_data!("[\"Test\" [\"123\"] 0x33]"));
+        } else {
+            assert!(false);
+        }
+    }
 
     #[test]
     fn env_stack_growth() {
@@ -1684,7 +1693,7 @@ mod tests {
         });
 
         eval!("[1 DUP] UNWRAP", env, result, {
-            assert_error!(result, "[\"Invalid value\" [DUP] 3]");
+            assert_error!(result, "[\"Invalid value\" ['DUP] 3]");
         });
 
         eval!("UNWRAP", env, result, {
@@ -1881,7 +1890,7 @@ mod tests {
     #[test]
     fn unknown_word() {
         eval!("NOTAWORD", env, result, {
-            assert_error!(result, "[\"Unknown word: NOTAWORD\" [NOTAWORD] 2]");
+            assert_error!(result, "[\"Unknown word: NOTAWORD\" ['NOTAWORD] 2]");
         });
     }
 
@@ -1908,7 +1917,7 @@ mod tests {
         });
 
         eval!("[NOTAWORD] TRY", env, result, {
-            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("[\"Unknown word: NOTAWORD\" [NOTAWORD] 2]"));
+            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("[\"Unknown word: NOTAWORD\" ['NOTAWORD] 2]"));
             assert_eq!(env.pop(), None);
         });
 


### PR DESCRIPTION
Instead of [descr [value] code] it is encoded as
[descr value code]

Solution: always encode details as a closure.

In the future, we might extend the error_program! macro
to support multiple value arguments (didn't have a need yet,
but it will come one day)

An important consequence of this change is that the words
are no longer written into details the same way.

Previously, they were written as [WORD]. However, one must
remember than 'WORD and [WORD] are no different as they are
just encoded values.

They are now encoded as ['WORD], and this is actually right
because previous version would violate the "unwrappability"
of the values, while this won't:

```
PumpkinDB> ['DUP] UNWRAP
0x83445550
PumpkinDB> [DUP] UNWRAP
Error: "Invalid value" 0x83445550 0x03
```