### PR TITLE
Problem: some storage code has to get unsafe with lmdb-zero

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Yurii Rashkovskii <yrashk@gmail.com>"]
 [dependencies]
 nom = "^2.1"
 snowflake = { git = "https://github.com/yrashk/snowflake.git", branch="pub-fields" }
-lmdb-zero = { git = "https://github.com/yrashk/lmdb-zero.git", branch="drop-accessor" }
+lmdb-zero = { git = "https://github.com/AltSysrq/lmdb-zero.git", branch="ergonomics" }
 mio = "0.6.4"
 slab = "0.3.0"
 config = "0.3.1"


### PR DESCRIPTION
Solution: thankfully, upcoming lmdb-zero 0.4.0 is improving
its ergonomics significantly and it also includes my patch
for dropping accessors; so this commit switches to the 0.4.0
preview branch ("ergonomics")

This doesn't remove the `Handle::cast_away` hack from storage
yet, but at the very least it will enable us to use Database
and Environment with less lifetime constraints (through Arcs)