### PR TITLE
Problem: indexing bigint as is breaks their natural order

### DIFF
--- a/doc/script/PAD.md
+++ b/doc/script/PAD.md
@@ -1,0 +1,41 @@
+# PAD
+
+Pads a binary with a number of bytes on left.
+
+Input stack: `a size byte`
+
+Output stack: `b`
+
+`PAD` takes a and pads it with up to `size` bytes of `byte` on the left, up to 1024
+bytes. This is an extremely important tool in building comparable collections over variable-length
+values (such as bigintegers, for example)
+
+## Allocation
+
+Allocates for a result of padding
+
+## Errors
+
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are less than three items on the stack
+
+[InvalidValue](./ERRORS/InvalidValue.md) error if `byte` is larger or smaller than one byte
+
+[InvalidValue](./ERRORS/InvalidValue.md) error if `size` is larger than 1024.
+
+## Examples
+
+```
+0x01 4 0 PAD => 0x00000001
+```
+
+## Tests
+
+```test
+pad : 0x01 4 0 PAD 0x00000001 EQUAL?.
+pad_1 : 0x01 4 0xff PAD 0xffffff01 EQUAL?.
+requires_three_items_0 : [PAD] TRY UNWRAP 0x04 EQUAL?.
+requires_three_items_1 : [1 PAD] TRY UNWRAP 0x04 EQUAL?.
+requires_three_items_2 : [1 1 PAD] TRY UNWRAP 0x04 EQUAL?.
+invalid_value : [0x01 4 "test" PAD] TRY UNWRAP 0x03 EQUAL?.
+too_big : [0x01 1025 0 PAD] TRY UNWRAP 0x03 EQUAL?.
+```

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -112,6 +112,7 @@ word!(GTP, (a, b => c), b"\x83GT?");
 word!(LENGTH, (a => b), b"\x86LENGTH");
 word!(CONCAT, (a, b => c), b"\x86CONCAT");
 word!(SLICE, (a, b, c => d), b"\x85SLICE");
+word!(PAD, (a, b, c => d), b"\x83PAD");
 
 // Category: arithmetics
 word!(UINT_ADD, (a, b => c), b"\x88UINT/ADD");
@@ -613,6 +614,7 @@ impl<'a> VM<'a> {
                            self => handle_equal,
                            self => handle_concat,
                            self => handle_slice,
+                           self => handle_pad,
                            self => handle_uint_add,
                            self => handle_uint_sub,
                            self => handle_length,
@@ -947,6 +949,35 @@ impl<'a> VM<'a> {
         }
 
         env.push(&slice[start_int..end_int]);
+
+        Ok((env, None))
+    }
+
+    #[inline]
+    fn handle_pad(&mut self, mut env: Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
+        word_is!(env, word, PAD);
+        let byte = stack_pop!(env);
+        let size = stack_pop!(env);
+        let value = stack_pop!(env);
+
+        if byte.len() != 1 {
+            return Err((env, error_invalid_value!(byte)));
+        }
+
+        let size_int = BigUint::from_bytes_be(size).to_u64().unwrap() as usize;
+
+        if size_int > 1024 {
+            return Err((env, error_invalid_value!(size)));
+        }
+
+        let slice = alloc_slice!(size_int, env);
+
+        for i in 0..size_int-value.len() {
+            slice[i] = byte[0];
+        }
+        slice[size_int-value.len()..].copy_from_slice(value);
+
+        env.push(slice);
 
         Ok((env, None))
     }


### PR DESCRIPTION
```
PumpkinDB> 0xff 0xfeff GT?
0x01
```

Solution: add PAD, a word to pad any value up to 1024 bytes
so that they compare well:

```
PumpkinDB> [4 0 PAD] 'PAD/64 DEF 0xff PAD/64 0xfeff PAD/64 GT?
0x00
```

Resolves #25