### PR TITLE
Problem: equality indices need to hash values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ glob = "0.2.11"
 regex = "0.2.1"
 crossbeam = "0.2.10"
 tempdir = "0.3.5"
+rust-crypto = "^0.2"
 
 [dev-dependencies]
 quickcheck = "0.4.1"

--- a/doc/script/HASH/SHA1.md
+++ b/doc/script/HASH/SHA1.md
@@ -1,0 +1,28 @@
+# HASH/SHA1
+
+Puts the SHA-1 hash of the top item on the stack back to the top of the stack
+
+Input stack: `a`
+
+Output stack: `b`
+
+## Allocation
+
+Allocates for the result of the hashing
+
+## Errors
+
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are no items on the stack
+
+## Examples
+
+```
+"The quick brown fox jumps over the lazy dog" HASH/SHA1 => 0x2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+```
+
+## Tests
+
+```test
+works : "The quick brown fox jumps over the lazy dog" HASH/SHA1 0x2fd4e1c67a2d28fced849ee1bb76e7391b93eb12 EQUAL?.
+empty_stack : [HASH/SHA1] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/HASH/SHA224.md
+++ b/doc/script/HASH/SHA224.md
@@ -1,0 +1,28 @@
+# HASH/SHA224
+
+Puts the SHA-224 hash of the top item on the stack back to the top of the stack
+
+Input stack: `a`
+
+Output stack: `b`
+
+## Allocation
+
+Allocates for the result of the hashing
+
+## Errors
+
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are no items on the stack
+
+## Examples
+
+```
+"The quick brown fox jumps over the lazy dog" HASH/SHA224 => 0x730e109bd7a8a32b1cb9d9a09aa2325d2430587ddbc0c38bad911525
+```
+
+## Tests
+
+```test
+works : "" HASH/SHA224 0xd14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f EQUAL?.
+empty_stack : [HASH/SHA224] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/HASH/SHA256.md
+++ b/doc/script/HASH/SHA256.md
@@ -1,0 +1,28 @@
+# HASH/SHA256
+
+Puts the SHA-256 hash of the top item on the stack back to the top of the stack
+
+Input stack: `a`
+
+Output stack: `b`
+
+## Allocation
+
+Allocates for the result of the hashing
+
+## Errors
+
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are no items on the stack
+
+## Examples
+
+```
+"The quick brown fox jumps over the lazy dog" HASH/SHA256 => 0xd7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592
+```
+
+## Tests
+
+```test
+works : "" HASH/SHA256 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 EQUAL?.
+empty_stack : [HASH/SHA256] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/HASH/SHA384.md
+++ b/doc/script/HASH/SHA384.md
@@ -1,0 +1,28 @@
+# HASH/SHA384
+
+Puts the SHA-384 hash of the top item on the stack back to the top of the stack
+
+Input stack: `a`
+
+Output stack: `b`
+
+## Allocation
+
+Allocates for the result of the hashing
+
+## Errors
+
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are no items on the stack
+
+## Examples
+
+```
+"The quick brown fox jumps over the lazy dog" HASH/SHA384 => 0xca737f1014a48f4c0b6dd43cb177b0afd9e5169367544c494011e3317dbf9a509cb1e5dc1e85a941bbee3d7f2afbc9b1
+```
+
+## Tests
+
+```test
+works : "" HASH/SHA384 0x38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b EQUAL?.
+empty_stack : [HASH/SHA384] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/HASH/SHA512-224.md
+++ b/doc/script/HASH/SHA512-224.md
@@ -1,0 +1,28 @@
+# HASH/SHA512-224
+
+Puts the SHA-512/224 hash of the top item on the stack back to the top of the stack
+
+Input stack: `a`
+
+Output stack: `b`
+
+## Allocation
+
+Allocates for the result of the hashing
+
+## Errors
+
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are no items on the stack
+
+## Examples
+
+```
+"The quick brown fox jumps over the lazy dog" HASH/SHA512-224 => 0x944cd2847fb54558d4775db0485a50003111c8e5daa63fe722c6aa37
+```
+
+## Tests
+
+```test
+works : "" HASH/SHA512-224 0x6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4 EQUAL?.
+empty_stack : [HASH/SHA512-224] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/HASH/SHA512-256.md
+++ b/doc/script/HASH/SHA512-256.md
@@ -1,0 +1,28 @@
+# HASH/SHA512-256
+
+Puts the SHA-512/256 hash of the top item on the stack back to the top of the stack
+
+Input stack: `a`
+
+Output stack: `b`
+
+## Allocation
+
+Allocates for the result of the hashing
+
+## Errors
+
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are no items on the stack
+
+## Examples
+
+```
+"The quick brown fox jumps over the lazy dog" HASH/SHA512-256 => 0xdd9d67b371519c339ed8dbd25af90e976a1eeefd4ad3d889005e532fc5bef04d
+```
+
+## Tests
+
+```test
+works : "" HASH/SHA512-256 0xc672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a EQUAL?.
+empty_stack : [HASH/SHA512-256] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/HASH/SHA512.md
+++ b/doc/script/HASH/SHA512.md
@@ -1,0 +1,28 @@
+# HASH/SHA512
+
+Puts the SHA-512 hash of the top item on the stack back to the top of the stack
+
+Input stack: `a`
+
+Output stack: `b`
+
+## Allocation
+
+Allocates for the result of the hashing
+
+## Errors
+
+[EmptyStack](./ERRORS/EmptyStack.md) error if there are no items on the stack
+
+## Examples
+
+```
+"The quick brown fox jumps over the lazy dog" HASH/SHA512 => 0x07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb642e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6
+```
+
+## Tests
+
+```test
+works : "" HASH/SHA512 0xcf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e EQUAL?.
+empty_stack : [HASH/SHA512] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/src/crates.rs
+++ b/src/crates.rs
@@ -41,3 +41,5 @@ extern crate config;
 #[macro_use]
 extern crate lazy_static;
 
+extern crate crypto;
+

--- a/src/script/hash.rs
+++ b/src/script/hash.rs
@@ -1,0 +1,68 @@
+// Copyright (c) 2017, All Contributors (see CONTRIBUTORS file)
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//!
+//! # Hashing primitives
+//!
+//! This module handles hashing data
+//!
+word!(HASH_SHA1, b"\x89HASH/SHA1");
+word!(HASH_SHA224, b"\x8BHASH/SHA224");
+word!(HASH_SHA256, b"\x8BHASH/SHA256");
+word!(HASH_SHA384, b"\x8BHASH/SHA384");
+word!(HASH_SHA512, b"\x8BHASH/SHA512");
+word!(HASH_SHA512_224, b"\x8FHASH/SHA512-224");
+word!(HASH_SHA512_256, b"\x8FHASH/SHA512-256");
+
+/*
+ * `Sha224`, which is the 32-bit `Sha256` algorithm with the result truncated to 224 bits.
+ * `Sha256`, which is the 32-bit `Sha256` algorithm.
+ * `Sha384`, which is the 64-bit `Sha512` algorithm with the result truncated to 384 bits.
+ * `Sha512`, which is the 64-bit `Sha512` algorithm.
+ * `Sha512Trunc224`, which is the 64-bit `Sha512` algorithm with the result truncated to 224 bits.
+ * `Sha512Trunc256`, which is the 64-bit `Sha512` algorithm with the result truncated to 256 bits.
+*/
+
+use super::{Env, EnvId, PassResult, Error, ERROR_EMPTY_STACK, offset_by_size};
+use crypto::digest::Digest;
+use crypto::sha1::Sha1;
+use crypto::sha2::*;
+
+use std::marker::PhantomData;
+
+pub struct Handler<'a> {
+    phantom: PhantomData<&'a ()>
+}
+
+macro_rules! hash_word {
+    ($name : ident, $constant: ident, $i: ident, $size: expr) => {
+    #[inline]
+    pub fn $name(&mut self, env: &mut Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
+        word_is!(env, word, $constant);
+        let a = stack_pop!(env);
+        let mut hasher = $i::new();
+        hasher.input(a);
+        let mut slice = alloc_slice!($size, env);
+        hasher.result(&mut slice);
+        env.push(slice);
+        Ok(())
+    }
+    };
+}
+
+impl<'a> Handler<'a> {
+    pub fn new() -> Self {
+        Handler { phantom: PhantomData }
+    }
+
+    hash_word!(handle_hash_sha1, HASH_SHA1, Sha1, 20);
+    hash_word!(handle_hash_sha224, HASH_SHA224, Sha224, 28);
+    hash_word!(handle_hash_sha256, HASH_SHA256, Sha256, 32);
+    hash_word!(handle_hash_sha384, HASH_SHA384, Sha384, 48);
+    hash_word!(handle_hash_sha512, HASH_SHA512, Sha512, 64);
+    hash_word!(handle_hash_sha512_224, HASH_SHA512_224, Sha512Trunc224, 28);
+    hash_word!(handle_hash_sha512_256, HASH_SHA512_256, Sha512Trunc256, 32);
+
+}

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -428,6 +428,7 @@ use pubsub;
 
 pub mod storage;
 pub mod timestamp_hlc;
+pub mod hash;
 
 /// VM is a PumpkinScript scheduler and interpreter. This is the
 /// most central part of this module.
@@ -469,6 +470,7 @@ pub struct VM<'a> {
     publisher: pubsub::PublisherAccessor<Vec<u8>>,
     storage: storage::Handler<'a>,
     hlc: timestamp_hlc::Handler<'a>,
+    hash: hash::Handler<'a>
 }
 
 unsafe impl<'a> Send for VM<'a> {}
@@ -502,6 +504,7 @@ impl<'a> VM<'a> {
             publisher: publisher,
             storage: storage::Handler::new(db_env, db),
             hlc: timestamp_hlc::Handler::new(),
+            hash: hash::Handler::new()
         }
     }
 
@@ -673,6 +676,14 @@ impl<'a> VM<'a> {
                            self.hlc => handle_hlc,
                            self.hlc => handle_hlc_lc,
                            self.hlc => handle_hlc_tick,
+                           // hashing
+                           self.hash => handle_hash_sha1,
+                           self.hash => handle_hash_sha224,
+                           self.hash => handle_hash_sha256,
+                           self.hash => handle_hash_sha384,
+                           self.hash => handle_hash_sha512,
+                           self.hash => handle_hash_sha512_224,
+                           self.hash => handle_hash_sha512_256,
                            // pubsub
                            self => handle_send,
                            // features


### PR DESCRIPTION
Solution: provide SHA1 and SHA2 hashes. Those might not be
the best hashes in terms of computational efficiency for indexes,
but we'll see how well they fit. Even if ultimately other hashing
primitives will be used for indexing, these hashes are still very
useful.

Closes #85