### PR TITLE
Problem: a lot of words would benefit from scoped evaluation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,6 @@ quickcheck_macros = "0.4.1"
 matches = "0.1.4"
 
 [features]
-experimental = ["scoped_dictionary"]
+default = ["scoped_dictionary"]
+experimental = []
 scoped_dictionary = []

--- a/doc/FEATURES.md
+++ b/doc/FEATURES.md
@@ -20,4 +20,11 @@ in`default`), the feature gate can be dropped.
 
 ## Current experimental features
 
+## Graduated features
+
+Graduated features are enabled by default, but in the source code,
+they are still behind a feature gate. This means that if things go
+wrong, they can still be easily demoted or dropped altogether. If
+everything is good, though, the gate will be eventually dropped.
+
 * `scoped_dictionary` ([issue #71](https://github.com/PumpkinDB/PumpkinDB/issues/71))

--- a/doc/script/EVAL/SCOPED.md
+++ b/doc/script/EVAL/SCOPED.md
@@ -1,6 +1,6 @@
 # EVAL/SCOPED
 
-## Experimental feature: `scoped_dictionary`
+## Graduated feature: `scoped_dictionary`
 
 Takes the topmost item and evaluates it as a PumpkinScript
 program on the current stack with a clone of the dictionary


### PR DESCRIPTION
Simply because it's easier to write words without juggling
stack too much to shuffle data around; it's simpler to bind
a value to a name for the duration of the word.

Solution: graduate `scoped_dictionary` feature

---

I move to graduate (but not to drop the feature gate altogether yet) `scoped_dictionary` (tracking issue #71)