### PR TITLE
Problem: it's very inconvenient to inject values into closures

### DIFF
--- a/doc/script/README.md
+++ b/doc/script/README.md
@@ -45,6 +45,12 @@ syntax (\`word) that can embed a value of a word into this code:
 unwrapping : 1 'a SET [`a] 'b SET 2 'a SET b EVAL 0x01 EQUAL?.
 ```
 
+It is also possible to unwrap multiple levels:
+
+```test
+unwrapping_multiple : 1 'a SET [[``a] EVAL] 'b SET 2 'a SET b EVAL 0x01 EQUAL?.
+```
+
 (this verifies that the closure we save in `b` remains at 1
 while we re-set `a` to 2)
 

--- a/doc/script/README.md
+++ b/doc/script/README.md
@@ -33,10 +33,18 @@ with binaries represented as:
 
 The rest of the instructions considered to be words.
 
+Example: `"Hello" 0x20 "world" CONCAT CONCAT`
+
 One additional piece of syntax is code included within square
 brackets: `[DUP]`. This means that the parser will take the code inside,
 compile it to the binary form and add as a data push. This is useful for
-words like [EVAL](EVAL.md).
+words like [EVAL](EVAL.md). Inside of this syntax, you can use so-called "unwrapping"
+syntax (\`word) that can embed a value of a word into this code:
 
-Example: `"Hello" 0x20 "world" CONCAT CONCAT`
+```test
+unwrapping : 1 'a SET [`a] 'b SET 2 'a SET b EVAL 0x01 EQUAL?.
+```
+
+(this verifies that the closure we save in `b` remains at 1
+while we re-set `a` to 2)
 

--- a/src/script/textparser.rs
+++ b/src/script/textparser.rs
@@ -141,23 +141,89 @@ named!(string<Vec<u8>>,  alt!(do_parse!(tag!(b"\"\"") >> (vec![0])) |
                          do_parse!(
                          str: delimited!(char!('"'), is_not!("\""), char!('"')) >>
                               (string_to_vec(str)))));
-named!(code<Vec<u8>>, do_parse!(
-                         prog: delimited!(char!('['), ws!(program), char!(']')) >>
-                               (sized_vec(prog))));
 named!(comment<Vec<u8>>, do_parse!(delimited!(char!('('), is_not!(")"), char!(')')) >> (vec![])));
-named!(item<Vec<u8>>, alt!(comment | binary | string | uint | code | wordref | word));
+named!(item<Vec<u8>>, alt!(comment | binary | string | uint | wrap | wordref | word));
+
+fn unwrap_word(mut word: Vec<u8>) -> Vec<u8> {
+    let mut vec = Vec::new();
+    vec.extend_from_slice(b"`");
+    vec.append(&mut word);
+    vec
+}
+
+fn rewrap(prog: Vec<Vec<u8>>) -> Vec<u8> {
+    let mut vec = Vec::new();
+    let mut acc = Vec::new();
+    let mut unwrapped = false;
+    let mut counter = 0;
+    for item in prog {
+        if item.len() > 0 && item[0] == b'`' {
+            if acc.len() > 0 {
+                vec.append(&mut sized_vec(flatten_program(acc.clone())));
+                acc.clear();
+                counter += 1;
+            }
+            counter += 1;
+            vec.extend_from_slice(&item[1..]);
+            vec.extend_from_slice(b"\x01\x01");
+            vec.append(&mut prefix_word(b"WRAP"));
+            unwrapped = true;
+        } else {
+            acc.push(item.clone());
+        }
+    }
+    if acc.len() > 0 {
+        if unwrapped {
+            vec.append(&mut sized_vec(flatten_program(acc.clone())));
+            counter += 1;
+            acc.clear();
+        } else {
+            vec.append(&mut flatten_program(acc.clone()));
+            acc.clear();
+        }
+    }
+    if unwrapped {
+        for _ in 0..counter - 1 {
+            vec.append(&mut prefix_word(b"CONCAT"));
+        }
+        vec
+    } else {
+        sized_vec(vec)
+    }
+}
+
+named!(unwrap<Vec<u8>>, do_parse!(
+                              tag!(b"`")                 >>
+                        word: word                       >>
+                              (unwrap_word(word))));
+named!(wrap<Vec<u8>>, do_parse!(
+                         prog: delimited!(char!('['), ws!(wrapped_program), char!(']')) >>
+                               (rewrap(prog))));
+named!(wrapped_item<Vec<u8>>, alt!(item | unwrap));
+named!(wrapped_program<Vec<Vec<u8>>>, alt!(do_parse!(
+                               take_while!(is_multispace)                        >>
+                            v: eof                                               >>
+                               (vec![v]))
+                              | do_parse!(
+                               take_while!(is_multispace)                        >>
+                         item: separated_list!(multispace, wrapped_item)         >>
+                               take_while!(is_multispace)                        >>
+                               (item))));
+
 named!(program<Vec<u8>>, alt!(do_parse!(
                                take_while!(is_multispace)                        >>
-                            v: eof                                          >>
+                            v: eof                                               >>
                                (v))
                               | do_parse!(
                                take_while!(is_multispace)                        >>
-                         item: separated_list!(multispace, item)            >>
+                         item: separated_list!(multispace, item)                 >>
                                take_while!(is_multispace)                        >>
                                (flatten_program(item)))));
+
 named!(pub programs<Vec<Vec<u8>>>, do_parse!(
-                         item: separated_list!(tag!(b"."), program)  >>
+                         item: separated_list!(tag!(b"."), program)              >>
                                (item)));
+
 
 /// Parses human-readable PumpkinScript
 ///
@@ -174,7 +240,13 @@ named!(pub programs<Vec<Vec<u8>>>, do_parse!(
 /// One additional piece of syntax is code included within square
 /// brackets: `[DUP]`. This means that the parser will take the code inside,
 /// compile it to the binary form and add as a data push. This is useful for
-/// words like EVAL
+/// words like EVAL. Inside of this syntax, you can use so-called "unwrapping"
+/// syntax that can embed a value of a word into this code:
+///
+/// ```norun
+/// PumpkinDB> 1 'a SET [`a] 'b SET 2 'a SET b EVAL
+/// 0x01
+/// ```
 ///
 /// # Example
 ///
@@ -320,11 +392,17 @@ mod tests {
     }
 
     #[test]
-    fn test_code() {
+    fn test_wrap() {
         let script = parse("[DUP]").unwrap();
         let script_spaced = parse("[ DUP ]").unwrap();
         assert_eq!(script, vec![4, 0x83, b'D', b'U', b'P']);
         assert_eq!(script_spaced, vec![4, 0x83, b'D', b'U', b'P']);
+    }
+
+    #[test]
+    fn test_empty_wrap() {
+        let script = parse("[]").unwrap();
+        assert_eq!(script, vec![0]);
     }
 
     #[test]
@@ -333,6 +411,16 @@ mod tests {
         let (_, mut progs) = programs(str.as_bytes()).unwrap();
         assert_eq!(Vec::from(progs.pop().unwrap()), parse("BURP : DURP").unwrap());
         assert_eq!(Vec::from(progs.pop().unwrap()), parse("SOMETHING : BURP DURP").unwrap());
+    }
+
+
+    #[test]
+    fn unwrapping() {
+        assert_eq!(parse("[`val DUP]").unwrap(), parse("val 1 WRAP [DUP] CONCAT").unwrap());
+        assert_eq!(parse("[`val]").unwrap(), parse("val 1 WRAP").unwrap());
+        assert_eq!(parse("[1 `val DUP]").unwrap(), parse("[1] val 1 WRAP [DUP] CONCAT CONCAT").unwrap());
+        assert_eq!(parse("[1 `val DUP `val]").unwrap(), parse("[1] val 1 WRAP [DUP] val 1 WRAP CONCAT CONCAT CONCAT").unwrap());
+        assert_eq!(parse("[1 `val]").unwrap(), parse("[1] val 1 WRAP CONCAT").unwrap());
     }
 
 }


### PR DESCRIPTION
Basically, there's a situation when we pass closures between scopes. This is sneaky:

```
CURSOR/DOWHILE : ['iterator SET 'closure SET 'c SET
                   [c closure EVAL [c iterator EVAL] [0] IFELSE] DOWHILE] EVAL/SCOPED.
?CURSOR/DOWHILE : ['iterator SET 'closure SET 'c SET
                   c [?CURSOR/CUR closure EVAL] iterator CURSOR/DOWHILE] EVAL/SCOPED.
```

will fail on this:

```
PumpkinDB> [CURSOR 'c SET c "testkey" CURSOR/SEEK? DROP c [UNWRAP  1]
'CURSOR/NEXT? ?CURSOR/DOWHILE] READ Error: "Invalid value"
0x1a17746573746b65790000000014a454200eded6f0000000000101 0x03
```

However, if I change the closure name like this:

```
?CURSOR/DOWHILE : ['iterator SET 'closure_ SET 'c SET
                   c [?CURSOR/CUR closure_ EVAL] iterator CURSOR/DOWHILE] EVAL/SCOPED.
```

then everything is fine:

```
PumpkinDB> [CURSOR 'c SET c "testkey" CURSOR/SEEK? DROP c [UNWRAP  1]
'CURSOR/NEXT? ?CURSOR/DOWHILE] READ
0x746573746b65790000000014a454200eded6f000000000 0x01
0x746573746b65790000000014a454200f336b4800000000 0x02
0x746573746b65790000000014a454200f79af9000000000 0x03
0x746573746b65790000000014a454200fb5513000000000 "Hello"
```

(See #71)

It basically boils down to the fact that `closure` here is passed
by name, not by value and is being subsequently shadowed with
another `closure`

Solution: add syntax sugar for "unwrapping" word values from
closures:

```
[?CURSOR/CUR `closure EVAL]
```