### PR TITLE
Problem: Small numbers are represented in a somewhat wasteful way

### DIFF
--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -7,23 +7,19 @@
 macro_rules! write_size_into_slice {
     ($size:expr, $slice: expr) => {
      match $size {
-        0...120 => {
-            $slice[0] = $size as u8;
-            1
-        }
-        121...255 => {
-            $slice[0] = 121u8;
+        0...255 => {
+            $slice[0] = 111u8;
             $slice[1] = $size as u8;
             2
         }
         256...65535 => {
-            $slice[0] = 122u8;
+            $slice[0] = 112u8;
             $slice[1] = ($size >> 8) as u8;
             $slice[2] = $size as u8;
             3
         }
         65536...4294967296 => {
-            $slice[0] = 123u8;
+            $slice[0] = 113u8;
             $slice[1] = ($size >> 24) as u8;
             $slice[2] = ($size >> 16) as u8;
             $slice[3] = ($size >> 8) as u8;

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -376,8 +376,8 @@ use nom;
 #[inline]
 pub fn offset_by_size(size: usize) -> usize {
     match size {
-        0...120 => 1,
-        120...255 => 2,
+        //0...255 => 1,
+        0...255 => 2,
         255...65535 => 3,
         65536...4294967296 => 5,
         _ => unreachable!(),
@@ -480,14 +480,14 @@ type PassResult<'a> = Result<(), Error>;
 const STACK_TRUE: &'static [u8] = b"\x01";
 const STACK_FALSE: &'static [u8] = b"\x00";
 
-const ERROR_UNKNOWN_WORD: &'static [u8] = b"\x01\x02";
-const ERROR_INVALID_VALUE: &'static [u8] = b"\x01\x03";
-const ERROR_EMPTY_STACK: &'static [u8] = b"\x01\x04";
-const ERROR_DECODING: &'static [u8] = b"\x01\x05";
-const ERROR_DUPLICATE_KEY: &'static [u8] = b"\x01\x06";
-const ERROR_UNKNOWN_KEY: &'static [u8] = b"\x01\x07";
-const ERROR_NO_TX: &'static [u8] = b"\x01\x08";
-const ERROR_DATABASE: &'static [u8] = b"\x01\x09";
+const ERROR_UNKNOWN_WORD: &'static [u8] = b"\x6F\x01\x02";
+const ERROR_INVALID_VALUE: &'static [u8] = b"\x6F\x01\x03";
+const ERROR_EMPTY_STACK: &'static [u8] = b"\x6F\x01\x04";
+const ERROR_DECODING: &'static [u8] = b"\x6F\x01\x05";
+const ERROR_DUPLICATE_KEY: &'static [u8] = b"\x6F\x01\x06";
+const ERROR_UNKNOWN_KEY: &'static [u8] = b"\x6F\x01\x07";
+const ERROR_NO_TX: &'static [u8] = b"\x6F\x01\x08";
+const ERROR_DATABASE: &'static [u8] = b"\x6F\x01\x09";
 
 impl<'a> VM<'a> {
     /// Creates an instance of VM with three communication channels:
@@ -619,7 +619,11 @@ impl<'a> VM<'a> {
         }
         if let nom::IResult::Done(rest, data) = binparser::data(program) {
             if env.aborting_try.is_empty() {
-                env.push(&data[offset_by_size(data.len())..]);
+                if data.len() == 1 && data[0] <= 10u8 {
+                    return handle_error!(env, error_decoding!());
+                } else {
+                    env.push(&data[offset_by_size(data.len())..]);
+                }
             }
             if rest.len() > 0 {
                 env.program.push(rest);
@@ -1108,7 +1112,9 @@ impl<'a> VM<'a> {
     fn handle_eval_validp(&mut self, env: &mut Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
         word_is!(env, word, EVAL_VALIDP);
         let a = stack_pop!(env);
-        if parse_bin(a).is_ok() {
+        if a.len() == 1 && a[0] <= 10u8 {
+            env.push(STACK_FALSE);
+        } else if parse_bin(a).is_ok() {
             env.push(STACK_TRUE);
         } else {
             env.push(STACK_FALSE);
@@ -1355,7 +1361,7 @@ mod tests {
 
     #[test]
     fn error_macro() {
-        if let Error::ProgramError(err) = error_program!("Test".as_bytes(), "123".as_bytes(),b"\x01\x33") {
+        if let Error::ProgramError(err) = error_program!("Test".as_bytes(), "123".as_bytes(), b"\x6F\x01\x33") {
             assert_eq!(err, parsed_data!("[\"Test\" [\"123\"] 0x33]"));
         } else {
             assert!(false);
@@ -1466,6 +1472,7 @@ mod tests {
         });
 
         eval!("1 TRY", env, result, {
+            println!("res: {:?}", env);
             assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("[\"Decoding error\" [] 5]"));
             assert_eq!(env.pop(), None);
         });

--- a/src/script/textparser.rs
+++ b/src/script/textparser.rs
@@ -32,18 +32,17 @@ fn hex_digit(v: u8) -> u8 {
 macro_rules! write_size {
     ($vec : expr, $size : expr) => {
       match $size {
-        0...120 => $vec.push($size as u8),
-        121...255 => {
-            $vec.push(121u8);
+        0...255 => {
+            $vec.push(111u8);
             $vec.push($size as u8);
         }
         256...65535 => {
-            $vec.push(122u8);
+            $vec.push(112u8);
             $vec.push(($size >> 8) as u8);
             $vec.push($size as u8);
         }
         65536...4294967296 => {
-            $vec.push(123u8);
+            $vec.push(113u8);
             $vec.push(($size >> 24) as u8);
             $vec.push(($size >> 16) as u8);
             $vec.push(($size >> 8) as u8);
@@ -137,7 +136,7 @@ named!(binary<Vec<u8>>, do_parse!(
                          hex: take_while1!(is_hex_digit)  >>
                               (bin(hex))
 ));
-named!(string<Vec<u8>>,  alt!(do_parse!(tag!(b"\"\"") >> (vec![0])) |
+named!(string<Vec<u8>>,  alt!(do_parse!(tag!(b"\"\"") >> (vec![111, 0])) |
                          do_parse!(
                          str: delimited!(char!('"'), is_not!("\""), char!('"')) >>
                               (string_to_vec(str)))));
@@ -165,7 +164,7 @@ fn rewrap(prog: Vec<u8>) -> Vec<u8> {
                 counter += 1;
             }
             vec.extend_from_slice(&unwrap[1..]);
-            vec.extend_from_slice(b"\x01\x01");
+            vec.extend_from_slice(b"\x6F\x01\x01");
             vec.append(&mut prefix_word(b"WRAP"));
 
             counter += 1;
@@ -195,8 +194,8 @@ fn rewrap(prog: Vec<u8>) -> Vec<u8> {
     }
 }
 
-use super::binparser::word_tag;
-named!(bin_word<Vec<u8>>, do_parse!(v: length_bytes!(word_tag) >> (Vec::from(v))));
+use script::binparser::word as bin_word_parser;
+named!(bin_word<Vec<u8>>, do_parse!(v: bin_word_parser >> (Vec::from(v))));
 
 named!(bin_unwrap<Vec<u8>>, do_parse!(
                               tag!(b"`")                   >>
@@ -296,14 +295,6 @@ mod tests {
     use core::str::FromStr;
 
     #[test]
-    fn test_empty() {
-        let script = parse("").unwrap();
-        assert_eq!(script, vec![]);
-        let script = parse("  ").unwrap();
-        assert_eq!(script, vec![]);
-    }
-
-    #[test]
     fn multiline() {
         let script_multiline = parse("\nHELP [\n\
         DROP] \n\
@@ -332,13 +323,13 @@ mod tests {
     #[test]
     fn test_wordref() {
         let script = parse("'HELLO").unwrap();
-        assert_eq!(script, vec![0x06, 0x85, b'H', b'E', b'L', b'L', b'O']);
+        assert_eq!(script, vec![0x6F, 0x06, 0x85, b'H', b'E', b'L', b'L', b'O']);
     }
 
     #[test]
     fn test_one() {
         let script = parse("0xAABB").unwrap();
-        assert_eq!(script, vec![2, 0xaa,0xbb]);
+        assert_eq!(script, vec![111, 2, 0xaa,0xbb]);
         let script = parse("HELLO").unwrap();
         assert_eq!(script, vec![0x85, b'H', b'E', b'L', b'L', b'O']);
     }
@@ -348,6 +339,7 @@ mod tests {
         let script = parse("1234567890").unwrap();
         let mut bytes = BigUint::from_str("1234567890").unwrap().to_bytes_be();
         let mut sized = Vec::new();
+        sized.push(111);
         sized.push(4);
         sized.append(&mut bytes);
         assert_eq!(script, sized);
@@ -360,14 +352,17 @@ mod tests {
         let mut vec = Vec::new();
 
         let mut bytes = BigUint::from_str("1").unwrap().to_bytes_be();
+        vec.push(111);
         vec.push(1);
         vec.append(&mut bytes);
 
         let mut bytes = BigUint::from_str("2").unwrap().to_bytes_be();
+        vec.push(111);
         vec.push(1);
         vec.append(&mut bytes);
 
         let mut bytes = BigUint::from_str("3").unwrap().to_bytes_be();
+        vec.push(111);
         vec.push(1);
         vec.append(&mut bytes);
 
@@ -380,6 +375,12 @@ mod tests {
         assert_eq!(script, parse("[0x01]").unwrap());
     }
 
+    #[test]
+    fn test_empty() {
+        let script = parse("\"\"").unwrap();
+        println!("Script: {:?}", script);
+        assert_eq!(script, parse("\"\"").unwrap());
+    }
 
     #[test]
     fn test_number_prefixed_word() {
@@ -390,15 +391,15 @@ mod tests {
     #[test]
     fn test_extra_spaces() {
         let script = parse(" 0xAABB  \"Hi\" ").unwrap();
-        assert_eq!(script, vec![2, 0xaa,0xbb, 2, b'H', b'i']);
+        assert_eq!(script, vec![111, 2, 0xaa,0xbb, 111, 2, b'H', b'i']);
     }
 
     #[test]
     fn test() {
         let script = parse("0xAABB DUP 0xFF00CC \"Hello\"").unwrap();
 
-        assert_eq!(script, vec![0x02, 0xAA, 0xBB, 0x83, b'D', b'U', b'P',
-                                0x03, 0xFF, 0x00, 0xCC, 0x05, b'H', b'e', b'l', b'l', b'o']);
+        assert_eq!(script, vec![111, 0x02, 0xAA, 0xBB, 0x83, b'D', b'U', b'P',
+                                111, 0x03, 0xFF, 0x00, 0xCC, 111, 0x05, b'H', b'e', b'l', b'l', b'o']);
     }
 
 
@@ -406,21 +407,21 @@ mod tests {
     fn test_empty_string() {
         let script = parse("\"\"").unwrap();
 
-        assert_eq!(script, vec![0]);
+        assert_eq!(script, vec![111, 0]);
     }
 
     #[test]
     fn test_wrap() {
         let script = parse("[DUP]").unwrap();
         let script_spaced = parse("[ DUP ]").unwrap();
-        assert_eq!(script, vec![4, 0x83, b'D', b'U', b'P']);
-        assert_eq!(script_spaced, vec![4, 0x83, b'D', b'U', b'P']);
+        assert_eq!(script, vec![111, 4, 0x83, b'D', b'U', b'P']);
+        assert_eq!(script_spaced, vec![111, 4, 0x83, b'D', b'U', b'P']);
     }
 
     #[test]
     fn test_empty_wrap() {
         let script = parse("[]").unwrap();
-        assert_eq!(script, vec![0]);
+        assert_eq!(script, vec![111, 0]);
     }
 
     #[test]


### PR DESCRIPTION
Solution: Indicate the first 10 numbers in the first 10 bytes.
