### PR TITLE
Problem: querying "the last update" isn't trivial

### DIFF
--- a/doc/script/QCURSOR/SEEKLAST.md
+++ b/doc/script/QCURSOR/SEEKLAST.md
@@ -1,0 +1,55 @@
+# ?CURSOR/SEEKLAST
+
+Sets the cursor at the key value pair with the last key that has a given prefix. 
+
+Input stack: `cursor prefix`
+
+Output stack: `[key value]` or `[]`
+
+If there are key/value pairs in the database that have their key
+prefixed with `prefix`, the `[key value]` pair with the largest key
+will be pushed onto the stack. Otherwise, `[]` will be pushed. Useful in conjunction with [UNWRAP](../UNWRAP.md),
+[SOME?](../SOMEQ.md) and [NONE?](../NONEQ.md).
+
+## Allocation
+
+Allocates for values to be put onto the stack
+
+## Errors
+
+NoTransaction error if there's no current write transaction
+
+InvalidValue error if the cursor identifier is incorrect or expired
+
+## Examples
+
+```
+["key" HLC CONCAT 1 ASSOC
+ "key" HLC CONCAT 2 ASSOC
+ "key" HLC CONCAT 3 ASSOC COMMIT] WRITE
+[CURSOR "key" ?CURSOR/SEEKLAST] READ UNWRAP SWAP DROP => 3
+```
+
+## Tests
+
+```test
+lastkey : ["a" HLC CONCAT 0 ASSOC
+           "key" HLC CONCAT 1 ASSOC
+           "key" HLC CONCAT 2 ASSOC
+           "key" HLC CONCAT 3 ASSOC COMMIT] WRITE
+          [CURSOR "key" ?CURSOR/SEEKLAST] READ UNWRAP
+          3 EQUAL?.
+not_lastkey : ["key" HLC CONCAT 1 ASSOC
+               "key" HLC CONCAT 2 ASSOC
+               "key" HLC CONCAT 3 ASSOC 
+               "zzzz" HLC CONCAT 4 ASSOC COMMIT] WRITE
+          [CURSOR "key" ?CURSOR/SEEKLAST] READ UNWRAP
+          3 EQUAL?.
+no_key : ["zzzz" HLC CONCAT 4 ASSOC COMMIT] WRITE
+          [CURSOR "key" ?CURSOR/SEEKLAST] READ NONE?.
+requires_txn : ["1" "1" ?CURSOR/SEEKLAST] TRY UNWRAP 0x08 EQUAL?.
+empty_stack : [?CURSOR/SEEKLAST] TRY UNWRAP 0x04 EQUAL?.
+empty_stack_1 : ["a" ?CURSOR/SEEKLAST] TRY UNWRAP 0x04 EQUAL?.
+invalid_cursor : [["1" "A" ?CURSOR/SEEKLAST] READ] TRY UNWRAP 0x03 EQUAL?.
+```
+

--- a/src/script/builtins
+++ b/src/script/builtins
@@ -5,6 +5,13 @@ NONE? : LENGTH 0 EQUAL?.
 SOME? : NONE? NOT.
 STACK : DEPTH WRAP.
 ( Cursor-related functionality )
+?CURSOR/SEEKLAST : ['key SET 'c SET
+                   key [] 511 key LENGTH UINT/SUB 0xff PAD CONCAT 'padded SET
+                   c padded CURSOR/SEEK?
+                   [`c ?CURSOR/CUR UNWRAP DROP 0 `key LENGTH SLICE `key EQUAL?
+                                      [`c ?CURSOR/CUR] [c ?CURSOR/PREV] IFELSE] 'positioning SET
+                   positioning [`c CURSOR/LAST? DROP `positioning EVAL] IFELSE
+                  ] EVAL/SCOPED.
 CURSOR/DOWHILE : ['iterator SET 'closure SET 'c SET
                    [c `closure EVAL [c ``iterator EVAL] [0] IFELSE] DOWHILE] EVAL/SCOPED.
 ?CURSOR/DOWHILE : ['iterator SET 'closure SET 'c SET


### PR DESCRIPTION
Since PumpkinDB doesn't allow to override keys, one has to write to a new key
value every time something is recorded.

We have at least one primitive for that right now, and that is HLC. Since it
is guaranteed to generate unique and monotonically growing values, they can be
used to sequence any collection of values. All one has to do is to compose the
key this way:

```
["key" HLC CONCAT "value" ASSOC COMMIT] WRITE
```

Similarly, things like journalling events can be done in the same way:

```
["journal" HLC CONCAT "id" "value" 2 WRAP ASSOC COMMIT] WRITE
```

However, how do we quickly find what's the last element in the collection?

Solution: introduce ?CURSOR/SEEKLAST that will always efficiently search
for the last key with a given prefix.

Closes #80 (at least for now!)