### PR TITLE
Problem: reusing term history requires re-typing period

### DIFF
--- a/src/bin/pumpkindb-term.rs
+++ b/src/bin/pumpkindb-term.rs
@@ -102,7 +102,7 @@ fn main() {
                     current_prompt = "..> ";
                 }
                 if program.len() > 0 {
-                    rl.add_history_entry(&program);
+                    rl.add_history_entry(format!("{}.", &program).as_str());
                     match script::parse(&program) {
                         Ok(compiled) => {
                             let uuid = Uuid::new_v4();


### PR DESCRIPTION
It's very annoying because I can't quickly repeat expressions,
I'll often forget to add the period.

Solution: make term record the period in the history so that when
searched or navigated to, they already come with the period.