### PR TITLE
Problem: 0.0.0.0:9981 doesn't seem to work in Windows

### DIFF
--- a/src/bin/pumpkindb-term.rs
+++ b/src/bin/pumpkindb-term.rs
@@ -50,7 +50,7 @@ fn main() {
         .arg(Arg::with_name("address")
             .help("Address to connect to")
             .required(true)
-            .default_value("0.0.0.0:9981")
+            .default_value("127.0.0.1:9981")
             .index(1))
         .get_matches();
 


### PR DESCRIPTION
By default, pumpkindb-term will try to connect to 0.0.0.0:9981,
however, on Windows, this will result in an error:

The requested address is not valid in its context

Solution: replace 0.0.0.0 with 127.0.0.1