### PR TITLE
Problem: can't execute doctests in Windows

### DIFF
--- a/src/bin/pumpkindb-doctests.rs
+++ b/src/bin/pumpkindb-doctests.rs
@@ -81,7 +81,7 @@ fn eval(name: &[u8], script: &[u8]) {
 }
 
 fn main() {
-    let re = Regex::new(r"```test\n((.+\n?)+)```").unwrap();
+    let re = Regex::new(r"```test\r?\n((.+\r?\n?)+)```").unwrap();
     for entry in glob("doc/script/**/*.md").expect("Failed to read glob pattern") {
         match entry {
             Ok(path) => {


### PR DESCRIPTION
Solution: adjust regex to check for \r\n newlines as well