### PR TITLE
Problem: term is trying to use ANSI escape sequences on Windows

### DIFF
--- a/src/bin/pumpkindb-term.rs
+++ b/src/bin/pumpkindb-term.rs
@@ -145,7 +145,11 @@ fn main() {
                                                 if rest.len() == 0 && top_level {
                                                     top_level = false;
                                                     if data.len() > 0 {
-                                                        let _ = write!(&mut s, "{}", Red.paint("Error: "));
+                                                        if cfg!(target_os = "windows") {
+                                                            let _ = write!(&mut s, "Error: ");
+                                                        } else {
+                                                            let _ = write!(&mut s, "{}", Red.paint("Error: "));
+                                                        }
                                                         input = Vec::from(data);
                                                     }
                                                 } else {


### PR DESCRIPTION
However, this doesn't end well there.

Solution: disable this behaviour on Windows