### PR TITLE
Problem: some of tests failing on Windows

### DIFF
--- a/src/bin/pumpkindb-doctests.rs
+++ b/src/bin/pumpkindb-doctests.rs
@@ -59,7 +59,11 @@ fn eval(name: &[u8], script: &[u8]) {
             Ok(ResponseMessage::EnvTerminated(_, stack, stack_size)) => {
                 let _ = sender.send(RequestMessage::Shutdown);
                 publisher_accessor.shutdown();
-                let mut script_env = Env::new_with_stack(stack, stack_size).unwrap();
+                let mut stack_ = Vec::with_capacity(stack.len());
+                for i in 0..(&stack).len() {
+                    stack_.push((&stack[i]).as_slice());
+                }
+                let mut script_env = Env::new_with_stack(stack_, stack_size).unwrap();
                 let val = script_env.pop().unwrap();
                 assert_eq!(Vec::from(val), vec![1], "{} was expected to succeeed", &name);
                 println!(" * {}", &name);

--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -314,14 +314,23 @@ macro_rules! eval {
                       let _ = sender.send(RequestMessage::Shutdown);
                       $publisher_accessor.shutdown();
                       let $result = Ok::<(), Error>(());
-                      let mut $env = Env::new_with_stack(stack, stack_size).unwrap();
+                      let mut stack_ = Vec::with_capacity(stack.len());
+                      for i in 0..(&stack).len() {
+                          stack_.push((&stack[i]).as_slice());
+                      }
+                      let mut $env = Env::new_with_stack(stack_, stack_size).unwrap();
                       $expr;
                    }
                    Ok(ResponseMessage::EnvFailed(_, err, stack, stack_size)) => {
                       let _ = sender.send(RequestMessage::Shutdown);
                       $publisher_accessor.shutdown();
                       let $result = Err::<(), Error>(err);
-                      let mut $env = Env::new_with_stack(stack.unwrap(), stack_size.unwrap()).unwrap();
+                      let stack = stack.unwrap();
+                      let mut stack_ = Vec::with_capacity(stack.len());
+                      for i in 0..(&stack).len() {
+                          stack_.push((&stack)[i].as_slice());
+                      }
+                      let mut $env = Env::new_with_stack(stack_, stack_size.unwrap()).unwrap();
                       $expr;
                    }
                    Err(err) => {

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -34,7 +34,7 @@ use std::collections::BTreeMap;
 
 pub struct Server {
     sender: Sender<RequestMessage<'static>>,
-    response_sender: Sender<ResponseMessage<'static>>,
+    response_sender: Sender<ResponseMessage>,
     evented_sender: mio_chan::Sender<(Token, Vec<u8>, Vec<u8>)>,
     receiver: mio_chan::Receiver<(Token, Vec<u8>, Vec<u8>)>,
     publisher: pubsub::PublisherAccessor<Vec<u8>>,


### PR DESCRIPTION
Solution: turns out, Windows was a great tool discovering
an issue in how we return the stack back from VM. It was
returned with a lifetime of the VM (which by that time might
have been gone). Now, a Vec<Vec<u8>> is returned instead
(a copy of the stack) which can safely be used later.

It wasn't a problem during testing on Linux and macOS, but
turned out to be an issue on Windows. Thanks, Microsoft!