### PR TITLE
Problem: cargo doc refuses to build the docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,21 @@ version = "0.1.0"
 authors = ["Ómar Yasin <omarkj@gmail.com>",
            "Yurii Rashkovskii <yrashk@gmail.com>"]
 
+
+[[bin]]
+doc = false
+name = "pumpkindb"
+
+[[bin]]
+doc = false
+name = "pumpkindb-term"
+path = "src/bin/pumpkindb-term.rs"
+
+[[bin]]
+doc = false
+name = "pumpkindb-doctests"
+path = "src/bin/pumpkindb-doctests.rs"
+
 [dependencies]
 nom = "^2.1"
 snowflake = { git = "https://github.com/yrashk/snowflake.git", branch="pub-fields" }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test
+.PHONY: test doc
 
 test:
 	cargo test -- --nocapture
@@ -6,3 +6,6 @@ test:
 	cargo test --features="scoped_dictionary" -- --nocapture
 	cargo run --bin pumpkindb-doctests
 	cargo run --bin pumpkindb-doctests --features="experimental"
+
+doc:
+	cargo doc --lib


### PR DESCRIPTION
```
Cannot document a package where a library and a binary have the same name.
Consider renaming one or marking the target as `doc = false`
```

Solution: do some Cargo.toml magic to avoid this