### PR TITLE
Problem: No way to represent negative integers

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -73,6 +73,8 @@
  * Numbers
    * [UINT/ADD](script/UINT/ADD.md)
    * [UINT/SUB](script/UINT/SUB.md)
+   * [INT/ADD](script/INT/ADD.md)
+   * [INT/SUB](script/INT/SUB.md)
  * Data formats
    * [JSON?](script/JSONQ.md)
    * [JSON/ARRAY?](script/JSON/ARRAYQ.md)

--- a/doc/script/INT/ADD.md
+++ b/doc/script/INT/ADD.md
@@ -1,0 +1,38 @@
+INT/ADD
+===
+
+{% method -%}
+
+Sums two signed integers
+
+Input stack: `a` `b`
+
+Output stack: `c`
+
+`AND` will push the sum of `a` and `b` to the top of the stack.
+
+{% common -%}
+
+```
+PumpkinDB> +1 +2 INT/ADD
++3
+```
+
+{% endmethod %}
+
+## Allocation
+
+Runtime allocations for decoding numbers and heap allocation
+for the result.
+
+## Errors
+
+[EmptyStack](../errors/EmptyStack.md) error if there are less than two items on the stack
+
+## Tests
+
+```test
+works : +2 +1 INT/ADD +3 EQUAL?.
+empty_stack : [INT/ADD] TRY UNWRAP 0x04 EQUAL?.
+empty_stack_1 : [+1 INT/ADD] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/INT/SUB.md
+++ b/doc/script/INT/SUB.md
@@ -1,0 +1,41 @@
+INT/SUB
+===
+
+{% method -%}
+
+Subtracts one signed integer from another
+
+Input stack: `a` `b`
+
+Output stack: `c`
+
+`SUB` will subtract of `b` from `a` and push it to the top of the stack.
+
+{% common -%}
+
+```
+PumpkinDB> +2 +1 INT/SUB
++1
+```
+
+{% endmethod %}
+
+## Allocation
+
+Runtime allocations for decoding numbers and heap allocation
+for the result.
+
+## Errors
+
+[EmptyStack](../errors/EmptyStack.md) error if there are less than two items on the stack
+
+[InvalidValue](../errors/InvalidValue.md) error if `a` is less than `b`
+
+## Tests
+
+```test
+works : +2 +1 INT/SUB +1 EQUAL?.
+negative_value : +1 +2 INT/SUB -1 EQUAL?.
+empty_stack : [INT/SUB] TRY UNWRAP 0x04 EQUAL?.
+empty_stack_1 : [+1 INT/SUB] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -59,7 +59,7 @@
 //!   from carrying these references outside of the scope of the transaction)
 //!
 
-use num_bigint::BigUint;
+use num_bigint::{BigUint, BigInt, Sign};
 use num_traits::{Zero, One};
 use num_traits::ToPrimitive;
 use core::ops::{Add, Sub};
@@ -120,6 +120,8 @@ word!(PAD, (a, b, c => d), b"\x83PAD");
 // Category: arithmetics
 word!(UINT_ADD, (a, b => c), b"\x88UINT/ADD");
 word!(UINT_SUB, (a, b => c), b"\x88UINT/SUB");
+word!(INT_ADD, (a, b => c), b"\x87INT/ADD");
+word!(INT_SUB, (a, b => c), b"\x87INT/SUB");
 
 // Category: Control flow
 #[cfg(feature = "scoped_dictionary")]
@@ -393,6 +395,14 @@ pub fn offset_by_size(size: usize) -> usize {
     }
 }
 
+pub fn bytes_to_bigint(bytes: &[u8]) -> BigInt {
+    let sign = match bytes[bytes.len()-1] {
+        0x01 => Sign::Minus,
+        _ => Sign::Plus
+    };
+    BigInt::from_bytes_be(sign, &bytes[..bytes.len()-1])
+}
+
 include!("macros.rs");
 
 use std::sync::mpsc;
@@ -660,6 +670,8 @@ impl<'a> VM<'a> {
                            self => handle_pad,
                            self => handle_uint_add,
                            self => handle_uint_sub,
+                           self => handle_int_add,
+                           self => handle_int_sub,
                            self => handle_length,
                            self => handle_dowhile,
                            self => handle_times,
@@ -1152,6 +1164,50 @@ impl<'a> VM<'a> {
         Ok(())
     }
 
+    fn handle_int_add(&mut self, env: &mut Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
+        word_is!(env, word, INT_ADD);
+        let a = stack_pop!(env);
+        let b = stack_pop!(env);
+
+        let a_int = bytes_to_bigint(a);
+        let b_int = bytes_to_bigint(b);
+
+        let c_int = a_int.add(b_int);
+
+        let (sign, mut c_bytes) = c_int.to_bytes_be();
+        if sign == Sign::Minus {
+            c_bytes.push(0x01);
+        } else {
+            c_bytes.push(0x00);
+        }
+
+        let slice = alloc_and_write!(c_bytes.as_slice(), env);
+        env.push(slice);
+        Ok(())
+    }
+
+    fn handle_int_sub(&mut self, env: &mut Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
+        word_is!(env, word, INT_SUB);
+        let a = stack_pop!(env);
+        let b = stack_pop!(env);
+
+        let a_int = bytes_to_bigint(a);
+        let b_int = bytes_to_bigint(b);
+
+        let c_int = b_int.sub(a_int);
+
+        let (sign, mut c_bytes) = c_int.to_bytes_be();
+        if sign == Sign::Minus {
+            c_bytes.push(0x01);
+        } else {
+            c_bytes.push(0x00);
+        }
+
+        let slice = alloc_and_write!(c_bytes.as_slice(), env);
+        env.push(slice);
+        Ok(())
+    }
+
     #[inline]
     fn handle_uint_sub(&mut self, env: &mut Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {
         word_is!(env, word, UINT_SUB);
@@ -1172,7 +1228,6 @@ impl<'a> VM<'a> {
         env.push(slice);
         Ok(())
     }
-
 
     #[inline]
     fn handle_eval(&mut self, env: &mut Env<'a>, word: &'a [u8], _: EnvId) -> PassResult<'a> {

--- a/src/script/textparser.rs
+++ b/src/script/textparser.rs
@@ -147,13 +147,13 @@ named!(sint<Vec<u8>>,
         sign: sign        >>
         biguint: biguint  >>
         ({
-           let mut b = biguint.to_bytes_be();
-           if sign == Sign::Minus {
-                b.push(0x01);
+           let mut bytes = if sign == Sign::Minus {
+                vec![0x01]
            } else {
-                b.push(0x00);
-           }
-           (sized_vec(b))
+                vec![0x00]
+           };
+           bytes.extend_from_slice(&biguint.to_bytes_be());
+           (sized_vec(bytes))
         })));
 
 named!(uint<Vec<u8>>,
@@ -491,7 +491,7 @@ mod tests {
 
     #[test]
     fn test_signed_ints() {
-        assert_eq!(parse("+1").unwrap(), vec![2, 1, 0]);
+        assert_eq!(parse("+1").unwrap(), vec![2, 0, 1]);
         assert_eq!(parse("-1").unwrap(), vec![2, 1, 1]);
     }
 

--- a/src/script/textparser.rs
+++ b/src/script/textparser.rs
@@ -7,7 +7,7 @@
 use nom::{IResult, ErrorKind};
 use nom::{is_hex_digit, multispace, is_digit};
 
-use num_bigint::BigUint;
+use num_bigint::{BigUint, Sign};
 use core::str::FromStr;
 use std::str;
 
@@ -87,7 +87,6 @@ fn sized_vec(s: Vec<u8>) -> Vec<u8> {
     write_size!(vec, size);
     vec.extend_from_slice(s.as_slice());
     vec
-
 }
 
 fn is_word_char(s: u8) -> bool {
@@ -126,11 +125,42 @@ fn is_multispace(s: u8) -> bool {
     s == b'\n' || s == b'\r' || s == b'\t' || s == b' '
 }
 
-named!(uint<Vec<u8>>, do_parse!(
-                     biguint: take_while1!(is_digit)      >>
-                              delim_or_end                >>
-                              (sized_vec(BigUint::from_str(str::from_utf8(biguint).unwrap())
-                                         .unwrap().to_bytes_be()))));
+named!(sign<Sign>,
+    do_parse!(
+        sign: alt!(tag!("+") | tag!("-")) >>
+        ({
+            if sign[0] == 45 {
+                Sign::Minus
+            } else {
+                Sign::Plus
+            }
+        })));
+
+named!(biguint<BigUint>,
+    do_parse!(
+        biguint: take_while1!(is_digit) >>
+        delim_or_end                    >>
+        (BigUint::from_str(str::from_utf8(biguint).unwrap()).unwrap())));
+
+named!(sint<Vec<u8>>,
+    do_parse!(
+        sign: sign        >>
+        biguint: biguint  >>
+        ({
+           let mut b = biguint.to_bytes_be();
+           if sign == Sign::Minus {
+                b.push(0x01);
+           } else {
+                b.push(0x00);
+           }
+           (sized_vec(b))
+        })));
+
+named!(uint<Vec<u8>>,
+    do_parse!(
+        biguint: biguint >>
+        (sized_vec(biguint.to_bytes_be()))));
+
 named!(word<Vec<u8>>, do_parse!(
                         word: take_while1!(is_word_char)  >>
                               (prefix_word(word))));
@@ -145,7 +175,7 @@ named!(string<Vec<u8>>,  alt!(do_parse!(tag!(b"\"\"") >> (vec![0])) |
                          str: delimited!(char!('"'), escaped!(is_not!("\"\\"), '\\', one_of!("\"n\\")), char!('"')) >>
                               (string_to_vec(str)))));
 named!(comment<Vec<u8>>, do_parse!(delimited!(char!('('), is_not!(")"), char!(')')) >> (vec![])));
-named!(item<Vec<u8>>, alt!(comment | binary | string | uint | wrap | wordref | word));
+named!(item<Vec<u8>>, alt!(comment | binary | string | uint | sint | wrap | wordref | word));
 
 fn unwrap_word(mut word: Vec<u8>) -> Vec<u8> {
     let mut vec = Vec::new();
@@ -457,6 +487,12 @@ mod tests {
     fn nested_unwrapping() {
         assert_eq!(parse("[[``val DUP]]").unwrap(), parse("val 1 WRAP [1 WRAP [DUP] CONCAT] CONCAT").unwrap());
         assert_eq!(parse("[[2 ``val DUP]]").unwrap(), parse("[[2]] val 1 WRAP [1 WRAP [DUP] CONCAT CONCAT] CONCAT CONCAT").unwrap());
+    }
+
+    #[test]
+    fn test_signed_ints() {
+        assert_eq!(parse("+1").unwrap(), vec![2, 1, 0]);
+        assert_eq!(parse("-1").unwrap(), vec![2, 1, 1]);
     }
 
 }


### PR DESCRIPTION
Solution: Provide a way to represent negative
integers (signed) and basic operations on them.

I opened this PR to have further discussions on how we
do numbers in the future within PumpkinDB. There are
some questions to how we:

* Represent signed and unsigned integers;
* Fail when the two types are used together (`10 -5 INT/SUB`);
* Encode signed integers efficiently.

Here I simply append a signing bit at the end of the byte array
generated by the bigint library. There are many much better
ways of doing this, such as using zigzag encoding. The problem
is our use of bigints, instead of sized integers as encoding differs
given how big the integer being signed is.

Another issue is our lack of type tags. We need a way on the binary
level to be able to differentiate between signed and unsigned
integers, the same way we now have different ways to represent
words.