### PR TITLE
Problem: lexicographical sorting doesn't work for INTs

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -73,6 +73,7 @@
  * Numbers
    * [UINT/ADD](script/UINT/ADD.md)
    * [UINT/SUB](script/UINT/SUB.md)
+   * [INT](script/INT/README.md)
    * [INT/ADD](script/INT/ADD.md)
    * [INT/SUB](script/INT/SUB.md)
  * Data formats

--- a/doc/script/INT/README.md
+++ b/doc/script/INT/README.md
@@ -1,0 +1,11 @@
+# INT
+
+By convention, INTs are signed big integers. They are serialized as a sign
+prefix (`0` for negative, `1` for positive and zero) followed by a variable
+sized bigint serialization.
+
+```test
+zero : -0 +0 EQUAL?.
+neg_zero : -1 +0 LT?.
+neg_pos : -1 +1 LT?.
+```


### PR DESCRIPTION
```
PumpkinDB> -1 +0 LT?.
0x00
PumpkinDB> -1 +0 LT?.
0x00
PumpkinDB> -1 +1 LT?.
0x00
PumpkinDB> +1 +2 LT?.
0x01
```

I think the problem is the sign representation chosen:

```
PumpkinDB> +1.
0x0001
PumpkinDB> -1.
0x0101
````

+ being represened with 0 which is less than 1 (used for representing -).

Solution: use 0 for negative, 1 for zero and positive

Fixes #142

cc @omarkj 