### PR TITLE
Problem: PAD panics with overflow when size is too small

### DIFF
--- a/doc/script/PAD.md
+++ b/doc/script/PAD.md
@@ -33,6 +33,8 @@ Allocates for a result of padding
 
 [InvalidValue](./errors/InvalidValue.md) error if `size` is larger than 1024.
 
+[InvalidValue](./errors/InvalidValue.md) error if `size` is lesser than the length of `a`.
+
 ## Tests
 
 ```test
@@ -43,4 +45,5 @@ requires_three_items_1 : [1 PAD] TRY UNWRAP 0x04 EQUAL?.
 requires_three_items_2 : [1 1 PAD] TRY UNWRAP 0x04 EQUAL?.
 invalid_value : [0x01 4 "test" PAD] TRY UNWRAP 0x03 EQUAL?.
 too_big : [0x01 1025 0 PAD] TRY UNWRAP 0x03 EQUAL?.
+too_small : [0x0102 1 0 PAD] TRY UNWRAP 0x03 EQUAL?.
 ```

--- a/src/script/binaries.rs
+++ b/src/script/binaries.rs
@@ -150,6 +150,10 @@ impl<'a> Handler<'a> {
             return Err(error_invalid_value!(size));
         }
 
+        if size_int < value.len() {
+            return Err(error_invalid_value!(size));
+        }
+
         let slice = alloc_slice!(size_int, env);
 
         for i in 0..size_int-value.len() {


### PR DESCRIPTION
When we are trying to pad a value that is larger than the
target size, PAD will panic with overflow on subtraction.

Solution: check if padded size is lesser than that of the
original value, and if it is, return an invalid value error.