### PR TITLE
Problem: VM is a confusing name and not very descriptive of what it does.

### DIFF
--- a/src/bin/pumpkindb-doctests.rs
+++ b/src/bin/pumpkindb-doctests.rs
@@ -24,7 +24,7 @@ use regex::Regex;
 use glob::glob;
 
 
-use pumpkindb::script::{RequestMessage, ResponseMessage, EnvId, Env, VM};
+use pumpkindb::script::{RequestMessage, ResponseMessage, EnvId, Env, Scheduler};
 use pumpkindb::script::{textparser, binparser};
 use pumpkindb::pubsub;
 
@@ -50,9 +50,9 @@ fn eval(name: &[u8], script: &[u8]) {
         let mut publisher = pubsub::Publisher::new();
         let publisher_accessor = publisher.accessor();
         let publisher_thread = scope.spawn(move || publisher.run());
-        let mut vm = VM::new(&env, &db, publisher_accessor.clone());
-        let sender = vm.sender();
-        let handle = scope.spawn(move || vm.run());
+        let mut scheduler = Scheduler::new(&env, &db, publisher_accessor.clone());
+        let sender = scheduler.sender();
+        let handle = scope.spawn(move || scheduler.run());
         let (callback, receiver) = mpsc::channel::<ResponseMessage>();
         let _ = sender.send(RequestMessage::ScheduleEnv(EnvId::new(), Vec::from(script), callback));
         match receiver.recv() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,10 +130,10 @@ fn main() {
 
     info!("Starting up");
 
-    let mut vm = script::VM::new(&ENV, &DB, PUBLISHER.lock().unwrap().clone());
-    let sender = vm.sender();
+    let mut scheduler = script::Scheduler::new(&ENV, &DB, PUBLISHER.lock().unwrap().clone());
+    let sender = scheduler.sender();
 
-    thread::spawn(move || vm.run());
+    thread::spawn(move || scheduler.run());
 
     server::run(config::get_int("server.port").unwrap(), sender, PUBLISHER.lock().unwrap().clone());
 

--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -279,10 +279,10 @@ macro_rules! eval {
                 let $publisher_accessor = publisher.accessor();
                 let publisher_thread = scope.spawn(move || publisher.run());
                 $($init)*
-                let mut vm = VM::new(&env, &db, $publisher_accessor.clone());
-                let sender = vm.sender();
+                let mut scheduler = Scheduler::new(&env, &db, $publisher_accessor.clone());
+                let sender = scheduler.sender();
                 let handle = scope.spawn(move || {
-                    vm.run();
+                    scheduler.run();
                 });
                 let script = parse($script).unwrap();
                 let (callback, receiver) = mpsc::channel::<ResponseMessage>();
@@ -348,11 +348,11 @@ macro_rules! bench_eval {
                 let publisher_accessor = publisher.accessor();
                 let publisher_accessor_ = publisher.accessor();
                 let publisher_thread = scope.spawn(move || publisher.run());
-                let mut vm = VM::new(&env, &db, publisher_accessor.clone());
-                let sender = vm.sender();
+                let mut scheduler = Scheduler::new(&env, &db, publisher_accessor.clone());
+                let sender = scheduler.sender();
                 let sender_ = sender.clone();
                 let handle = scope.spawn(move || {
-                    vm.run();
+                    scheduler.run();
                 });
                 let script = parse($script).unwrap();
                 $b.iter(move || {

--- a/src/script/mod_core.rs
+++ b/src/script/mod_core.rs
@@ -388,7 +388,7 @@ impl<'a> Handler<'a> {
 #[allow(unused_variables, unused_must_use, unused_mut)]
 mod tests {
 
-    use script::{Env, VM, Error, RequestMessage, ResponseMessage, EnvId, parse, offset_by_size};
+    use script::{Env, Scheduler, Error, RequestMessage, ResponseMessage, EnvId, parse, offset_by_size};
     use std::sync::mpsc;
     use std::fs;
     use std::thread;

--- a/src/script/mod_storage.rs
+++ b/src/script/mod_storage.rs
@@ -488,7 +488,7 @@ impl<'a> Handler<'a> {
 #[cfg(test)]
 #[allow(unused_variables, unused_must_use, unused_mut, unused_imports)]
 mod tests {
-    use script::{Env, VM, Error, RequestMessage, ResponseMessage, EnvId, parse, offset_by_size};
+    use script::{Env, Scheduler, Error, RequestMessage, ResponseMessage, EnvId, parse, offset_by_size};
     use std::sync::mpsc;
     use std::fs;
     use tempdir::TempDir;


### PR DESCRIPTION
Solution: Rename VM to Scheduler, which is a more
descriptive name for the functionality.