### PR TITLE
Problem: integers of different size can't be compared

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -75,9 +75,15 @@
  * Numbers
    * [UINT/ADD](script/UINT/ADD.md)
    * [UINT/SUB](script/UINT/SUB.md)
+   * [UINT/EQUAL?](script/UINT/EQUALQ.md)
+   * [UINT/LT?](script/UINT/LTQ.md)
+   * [UINT/GT?](script/UINT/GTQ.md)
    * [INT](script/INT/README.md)
    * [INT/ADD](script/INT/ADD.md)
    * [INT/SUB](script/INT/SUB.md)
+   * [INT/EQUAL?](script/INT/EQUALQ.md)
+   * [INT/LT?](script/INT/LTQ.md)
+   * [INT/GT?](script/INT/GTQ.md)
  * Data formats
    * [JSON?](script/JSONQ.md)
    * [JSON/ARRAY?](script/JSON/ARRAYQ.md)

--- a/doc/script/INT/EQUALQ.md
+++ b/doc/script/INT/EQUALQ.md
@@ -1,0 +1,39 @@
+# INT/EQUAL?
+
+{% method -%}
+
+Compares two topmost items for equality as signed big integers.
+
+Input stack: `a b`
+
+Output stack: `c`
+
+`INT/EQUAL?` will push `1` if they are equal, `0` otherwise.
+
+{% common -%}
+
+```
+PumpkinDB> 1 2 INT/EQUAL?
+0
+```
+
+{% endmethod %}
+
+## Allocation
+
+Runtime allocation for supporting primitives
+
+## Errors
+
+[EmptyStack](./errors/EmptyStack.md) error if there are less than two items on the stack
+
+## Tests
+
+```test
+invalid : [0xff 0xff INT/EQUAL?] TRY UNWRAP 0x03 EQUAL?.
+not_equal : -1 +0 INT/EQUAL? NOT.
+equal : +1000 +1000 INT/EQUAL?.
+equal_diff_size : 0x010001 0x0101 INT/EQUAL?.
+requires_two_items_0 : [INT/EQUAL?] TRY UNWRAP 0x04 EQUAL?.
+requires_two_items_1 : [1 INT/EQUAL?] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/INT/GTQ.md
+++ b/doc/script/INT/GTQ.md
@@ -1,0 +1,42 @@
+# INT/GT?
+
+{% method -%}
+
+Compares two topmost items as signed big integers.
+
+Input stack: `a b`
+
+Output stack: `a`
+
+`INT/GT?` will push `1` if `a` is strictly greater than `b`, `0` otherwise.
+
+{% common -%}
+
+```
+PumpkinDB> 0x10 0x20 INT/GT?
+0
+PumpkinDB> 0x20 0x10 INT/GT?
+1
+```
+
+{% endmethod %}
+
+## Allocation
+
+Runtime allocation for supporting primitives
+
+## Errors
+
+[EmptyStack](./errors/EmptyStack.md) error if there are less than two items on the stack
+
+## Tests
+
+```test
+invalid : [0xff 0xff INT/GT?] TRY UNWRAP 0x03 EQUAL?.
+less : +1 +2 INT/GT? NOT.
+greater : +2 +1 INT/GT?.
+greater_diff_size : 0x010002 0x0101 INT/GT?.
+equal : +1 +1 INT/GT? NOT.
+requires_two_items_0 : [INT/GT?] TRY UNWRAP 0x04 EQUAL?.
+requires_two_items_1 : [1 INT/GT?] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/INT/LTQ.md
+++ b/doc/script/INT/LTQ.md
@@ -1,0 +1,42 @@
+# INT/LT?
+
+{% method -%}
+
+Compares two topmost items as signed big integers.
+
+Input stack: `a b`
+
+Output stack: `a`
+
+`INT/LT?` will push `1` if `a` is strictly less than `b`, `0` otherwise.
+
+{% common -%}
+
+```
+PumpkinDB> 0x10 0x20 INT/LT?
+1
+PumpkinDB> 0x20 0x10 INT/LT?
+0
+```
+
+{% endmethod %}
+
+## Allocation
+
+Runtime allocation for supporting primitives
+
+## Errors
+
+[EmptyStack](./errors/EmptyStack.md) error if there are less than two items on the stack
+
+## Tests
+
+```test
+invalid : [0xff 0xff INT/LT?] TRY UNWRAP 0x03 EQUAL?.
+less : +1 +2 INT/LT?.
+less_diff_size : 0x010001 0x0110 INT/LT?.
+greater : +2 +1 INT/LT? NOT.
+equal : +1 +1 INT/LT? NOT.
+requires_two_items_0 : [INT/LT?] TRY UNWRAP 0x04 EQUAL?.
+requires_two_items_1 : [1 INT/LT?] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/UINT/EQUALQ.md
+++ b/doc/script/UINT/EQUALQ.md
@@ -1,0 +1,38 @@
+# UINT/EQUAL?
+
+{% method -%}
+
+Compares two topmost items for equality as unsigned big integers.
+
+Input stack: `a b`
+
+Output stack: `c`
+
+`UINT/EQUAL?` will push `1` if they are equal, `0` otherwise.
+
+{% common -%}
+
+```
+PumpkinDB> 1 2 UINT/EQUAL?
+0
+```
+
+{% endmethod %}
+
+## Allocation
+
+Runtime allocation for supporting primitives
+
+## Errors
+
+[EmptyStack](./errors/EmptyStack.md) error if there are less than two items on the stack
+
+## Tests
+
+```test
+not_equal : 1 0 UINT/EQUAL? NOT.
+equal : 1000 1000 UINT/EQUAL?.
+equal_diff_size : 0x01 0x0001 UINT/EQUAL?.
+requires_two_items_0 : [UINT/EQUAL?] TRY UNWRAP 0x04 EQUAL?.
+requires_two_items_1 : [1 UINT/EQUAL?] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/UINT/GTQ.md
+++ b/doc/script/UINT/GTQ.md
@@ -1,0 +1,41 @@
+# UINT/GT?
+
+{% method -%}
+
+Compares two topmost items as unsigned big integers.
+
+Input stack: `a b`
+
+Output stack: `a`
+
+`UINT/GT?` will push `1` if `a` is strictly greater than `b`, `0` otherwise.
+
+{% common -%}
+
+```
+PumpkinDB> 0x10 0x20 UINT/GT?
+0
+PumpkinDB> 0x20 0x10 UINT/GT?
+1
+```
+
+{% endmethod %}
+
+## Allocation
+
+Runtime allocation for supporting primitives
+
+## Errors
+
+[EmptyStack](./errors/EmptyStack.md) error if there are less than two items on the stack
+
+## Tests
+
+```test
+less : 0x10 0x20 UINT/GT? NOT.
+greater : 0x20 0x10 UINT/GT?.
+greater_diff_size : 0x0020 0x10 UINT/GT?.
+equal : 0x10 0x10 UINT/GT? NOT.
+requires_two_items_0 : [UINT/GT?] TRY UNWRAP 0x04 EQUAL?.
+requires_two_items_1 : [1 UINT/GT?] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/UINT/LTQ.md
+++ b/doc/script/UINT/LTQ.md
@@ -1,0 +1,41 @@
+# UINT/LT?
+
+{% method -%}
+
+Compares two topmost items as unsigned big integers.
+
+Input stack: `a b`
+
+Output stack: `a`
+
+`UINT/LT?` will push `1` if `a` is strictly less than `b`, `0` otherwise.
+
+{% common -%}
+
+```
+PumpkinDB> 0x10 0x20 UINT/LT?
+1
+PumpkinDB> 0x20 0x10 UINT/LT?
+0
+```
+
+{% endmethod %}
+
+## Allocation
+
+Runtime allocation for supporting primitives
+
+## Errors
+
+[EmptyStack](./errors/EmptyStack.md) error if there are less than two items on the stack
+
+## Tests
+
+```test
+less : 0x10 0x20 UINT/LT?.
+less_diff_size : 0x0010 0x20 UINT/LT?.
+greater : 0x20 0x10 UINT/LT? NOT.
+equal : 0x10 0x10 UINT/LT? NOT.
+requires_two_items_0 : [UINT/LT?] TRY UNWRAP 0x04 EQUAL?.
+requires_two_items_1 : [1 UINT/LT?] TRY UNWRAP 0x04 EQUAL?.
+```


### PR DESCRIPTION
```
PumpkinDB> 0xff 0xfa00 GT?.
0x01
```

And that's not true, because this means:

```
PumpkinDB> 255 64000 GT?.
0x01
```

(64000 > 255)

Solution: introduce EQUAL?, LT? and GT? for both UINT
and INT families:

```
PumpkinDB> 255 64000 UINT/GT?.
0x00
```

Closes #25