### PR TITLE
Problem: ?CURSOR/SEEKLAST and CURSOR/DOWHILE-PREFIXED fail

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -65,6 +65,7 @@
    * [LT?](script/LTQ.md)
    * [PAD](script/PAD.md)
    * [SLICE](script/SLICE.md)
+   * [STARTSWITH?](script/STARTSWITHQ.md)
  * Control flow
    * [DOWHILE](script/DOWHILE.md)
    * [EVAL](script/EVAL.md)

--- a/doc/script/CURSOR/DOWHILE-PREFIXED.md
+++ b/doc/script/CURSOR/DOWHILE-PREFIXED.md
@@ -51,4 +51,10 @@ cursor_dowhile_prefixed :
    COMMIT] WRITE
   ["testkey" [SWAP DROP 1] CURSOR/DOWHILE-PREFIXED] READ
   3 WRAP [1 2 3] EQUAL?.
+nextkey_short : ["key" HLC CONCAT 1 ASSOC
+               "key" HLC CONCAT 2 ASSOC
+               "key" HLC CONCAT 3 ASSOC
+               "z" 4 ASSOC COMMIT] WRITE
+          ["key" [SWAP DROP 1] CURSOR/DOWHILE-PREFIXED] READ
+          3 WRAP [1 2 3] EQUAL?.
 ```

--- a/doc/script/QCURSOR/SEEKLAST.md
+++ b/doc/script/QCURSOR/SEEKLAST.md
@@ -50,6 +50,12 @@ not_lastkey : ["key" HLC CONCAT 1 ASSOC
                "zzzz" HLC CONCAT 4 ASSOC COMMIT] WRITE
           [CURSOR "key" ?CURSOR/SEEKLAST] READ UNWRAP
           3 EQUAL?.
+nextkey_short : ["key" HLC CONCAT 1 ASSOC
+               "key" HLC CONCAT 2 ASSOC
+               "key" HLC CONCAT 3 ASSOC
+               "z" 4 ASSOC COMMIT] WRITE
+          [CURSOR "key" ?CURSOR/SEEKLAST] READ UNWRAP
+          3 EQUAL?.
 no_key : ["zzzz" HLC CONCAT 4 ASSOC COMMIT] WRITE
           [CURSOR "key" ?CURSOR/SEEKLAST] READ NONE?.
 requires_txn : ["1" "1" ?CURSOR/SEEKLAST] TRY UNWRAP 0x08 EQUAL?.

--- a/doc/script/STARTSWITHQ.md
+++ b/doc/script/STARTSWITHQ.md
@@ -1,0 +1,39 @@
+# STARTSWITH?
+
+{% method -%}
+
+Tests if binary starts with another binary
+
+Input stack: `a b`
+
+Output stack: `c`
+
+`STARTSWITH?` pushes `1` if binary `a` starts with binary `b`,
+`0` otherwise.
+
+{% common -%}
+
+```
+PumpkinDB> "ab" "a" STARTSWITH?
+0x01
+```
+
+{% endmethod %}
+
+## Allocation
+
+Runtime allocation
+
+## Errors
+
+[EmptyStack](./errors/EmptyStack.md) error if there are less than two items on the stack
+
+## Tests
+
+```test
+works : "ab" "a" STARTSWITH?.
+works_negative : "ab" "c" STARTSWITH? NOT.
+smaller_val : "a" "ab" STARTSWITH? NOT.
+empty_stack : [STARTSWITH?] TRY UNWRAP 0x04 EQUAL?.
+empty_stack_1 : ["a" STARTSWITH?] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/src/script/builtins
+++ b/src/script/builtins
@@ -12,11 +12,12 @@ TUCK : SWAP OVER.
 2NIP : 2SWAP 2DROP.
 2TUCK : 2SWAP 2OVER.
 -ROT : ROT ROT.
+STARTSWITH? : 2DUP LENGTH SWAP LENGTH SWAP UINT/LT? [2DROP 0] [DUP LENGTH 0 SWAP 2SWAP SWAP 2SWAP SLICE EQUAL?] IFELSE.
 ( Cursor-related functionality )
 ?CURSOR/SEEKLAST : ['key SET 'c SET
                    key [] 511 key LENGTH UINT/SUB 0xff PAD CONCAT 'padded SET
                    c padded CURSOR/SEEK?
-                   [`c ?CURSOR/CUR UNWRAP DROP 0 `key LENGTH SLICE `key EQUAL?
+                   [`c ?CURSOR/CUR UNWRAP DROP `key STARTSWITH?
                                       [`c ?CURSOR/CUR] [c ?CURSOR/PREV] IFELSE] 'positioning SET
                    positioning [`c CURSOR/LAST? DROP `positioning EVAL] IFELSE
                   ] EVAL/SCOPED.
@@ -26,7 +27,7 @@ CURSOR/DOWHILE : ['iterator SET 'closure SET 'c SET
                    c [?CURSOR/CUR `closure EVAL] iterator CURSOR/DOWHILE] EVAL/SCOPED.
 CURSOR/DOWHILE-PREFIXED : ['closure SET
                             'prefix SET
-                            [UNWRAP OVER 0 `prefix LENGTH SLICE `prefix EQUAL? [``closure EVAL] [2DROP 0] IFELSE]
+                            [UNWRAP OVER `prefix STARTSWITH? [``closure EVAL] [2DROP 0] IFELSE]
                             'closure1 SET
                             CURSOR 'c SET
                             c prefix CURSOR/SEEK?


### PR DESCRIPTION
Under certain circumstaneces, they product an Invalid Value
error. This happens when a key they encounter is actually
shorter than the prefix they are looking for.

Solution: instead of SLICE, use newly introduced STARTSWITH?
word to test key prefix matching.