### PR TITLE
Problem: There is only one scheduler, meaning pdb serializes every operation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ log = "0.3.6"
 log4rs = { version = "0.6.1", features = ["toml_format"] }
 serde_json = "0.9.8"
 clap = "2.20.5"
+num_cpus = "1.3.0"
 
 [dev-dependencies]
 quickcheck = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ log4rs = { version = "0.6.1", features = ["toml_format"] }
 serde_json = "0.9.8"
 clap = "2.20.5"
 num_cpus = "1.3.0"
+rand = "0.3.15"
 
 [dev-dependencies]
 quickcheck = "0.4.1"

--- a/src/bin/pumpkindb-doctests.rs
+++ b/src/bin/pumpkindb-doctests.rs
@@ -41,7 +41,6 @@ fn eval(name: &[u8], script: &[u8]) {
             .expect("can't open env")
     };
     let name = String::from(std::str::from_utf8(name).unwrap());
-
     let db = storage::Storage::new(&env);
     crossbeam::scope(|scope| {
         let mut publisher = pubsub::Publisher::new();

--- a/src/bin/pumpkindb-doctests.rs
+++ b/src/bin/pumpkindb-doctests.rs
@@ -23,10 +23,10 @@ use std::sync::mpsc;
 use regex::Regex;
 use glob::glob;
 
-
 use pumpkindb::script::{RequestMessage, ResponseMessage, EnvId, Env, Scheduler};
 use pumpkindb::script::{textparser, binparser};
 use pumpkindb::pubsub;
+use pumpkindb::database;
 
 use tempdir::TempDir;
 
@@ -42,10 +42,7 @@ fn eval(name: &[u8], script: &[u8]) {
     };
     let name = String::from(std::str::from_utf8(name).unwrap());
 
-    let db = lmdb::Database::open(&env,
-                                  None,
-                                  &lmdb::DatabaseOptions::new(lmdb::db::CREATE))
-        .expect("can't open database");
+    let db = database::Database::new(&env);
     crossbeam::scope(|scope| {
         let mut publisher = pubsub::Publisher::new();
         let publisher_accessor = publisher.accessor();

--- a/src/bin/pumpkindb-doctests.rs
+++ b/src/bin/pumpkindb-doctests.rs
@@ -26,7 +26,7 @@ use glob::glob;
 use pumpkindb::script::{RequestMessage, ResponseMessage, EnvId, Env, Scheduler};
 use pumpkindb::script::{textparser, binparser};
 use pumpkindb::pubsub;
-use pumpkindb::database;
+use pumpkindb::storage;
 
 use tempdir::TempDir;
 
@@ -42,7 +42,7 @@ fn eval(name: &[u8], script: &[u8]) {
     };
     let name = String::from(std::str::from_utf8(name).unwrap());
 
-    let db = database::Database::new(&env);
+    let db = storage::Storage::new(&env);
     crossbeam::scope(|scope| {
         let mut publisher = pubsub::Publisher::new();
         let publisher_accessor = publisher.accessor();

--- a/src/bin/pumpkindb-doctests.rs
+++ b/src/bin/pumpkindb-doctests.rs
@@ -47,7 +47,7 @@ fn eval(name: &[u8], script: &[u8]) {
         let mut publisher = pubsub::Publisher::new();
         let publisher_accessor = publisher.accessor();
         let publisher_thread = scope.spawn(move || publisher.run());
-        let mut scheduler = Scheduler::new(&env, &db, publisher_accessor.clone());
+        let mut scheduler = Scheduler::new(&db, publisher_accessor.clone());
         let sender = scheduler.sender();
         let handle = scope.spawn(move || scheduler.run());
         let (callback, receiver) = mpsc::channel::<ResponseMessage>();

--- a/src/crates.rs
+++ b/src/crates.rs
@@ -44,3 +44,5 @@ extern crate lazy_static;
 extern crate crypto;
 
 extern crate serde_json;
+
+extern crate rand;

--- a/src/crates.rs
+++ b/src/crates.rs
@@ -46,3 +46,6 @@ extern crate crypto;
 extern crate serde_json;
 
 extern crate rand;
+
+#[macro_use]
+extern crate log;

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,0 +1,32 @@
+use std::sync::Mutex;
+use lmdb;
+
+pub struct Database<'a> {
+    pub db: lmdb::Database<'a>,
+    pub gwl: Mutex<()>
+}
+
+pub trait GlobalWriteLock {
+    fn try_lock(&self) -> bool;
+}
+
+impl<'a> GlobalWriteLock for Database<'a> {
+    fn try_lock(&self) -> bool {
+        match self.gwl.try_lock() {
+            Ok(_) => true,
+            Err(_) => false
+        }
+    }
+}
+
+impl<'a> Database<'a> {
+    pub fn new(env: &'a lmdb::Environment) -> Database<'a> {
+        return Database {
+            db: lmdb::Database::open(env,
+                                     None,
+                                     &lmdb::DatabaseOptions::new(lmdb::db::CREATE))
+                .expect("can't open database"),
+            gwl: Mutex::new(())
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(slice_patterns, advanced_slice_patterns)]
 #![cfg_attr(test, feature(test))]
 
+#![cfg_attr(not(target_os = "windows"), feature(alloc, heap_api))]
 #![feature(alloc)]
 
 include!("crates.rs");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,4 @@ pub mod script;
 mod timestamp;
 #[allow(dead_code)]
 pub mod pubsub;
-pub mod database;
+pub mod storage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,4 @@ pub mod script;
 mod timestamp;
 #[allow(dead_code)]
 pub mod pubsub;
+pub mod database;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ pub mod script;
 pub mod server;
 pub mod timestamp;
 pub mod pubsub;
-pub mod database;
+pub mod storage;
 
 use std::thread;
 use std::sync::Arc;
@@ -40,8 +40,6 @@ use alloc::heap;
 use core::mem::size_of;
 
 use std::sync::Mutex;
-
-use database::{Database};
 
 lazy_static! {
  static ref ENV: Arc<lmdb::Environment> = {
@@ -89,7 +87,7 @@ lazy_static! {
     }
  };
 
- static ref DATABASE: Arc<Database<'static>> = Arc::new(Database::new(&ENV));
+ static ref DATABASE: Arc<storage::Storage<'static>> = Arc::new(storage::Storage::new(&ENV));
 
  static ref PUBLISHER: Mutex<pubsub::PublisherAccessor<Vec<u8>>> = {
      let mut publisher = pubsub::Publisher::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,14 +7,12 @@
 #![cfg_attr(test, feature(test))]
 
 #![cfg_attr(not(target_os = "windows"), feature(alloc, heap_api))]
-#![cfg_attr(target_os = "windows", feature(alloc))]
+#![feature(alloc)]
 
 include!("crates.rs");
 
 extern crate num_cpus;
 extern crate log4rs;
-#[macro_use]
-extern crate log;
 
 pub mod script;
 pub mod server;
@@ -22,72 +20,25 @@ pub mod timestamp;
 pub mod pubsub;
 pub mod storage;
 
+use std::fs;
 use std::thread;
 use std::sync::Arc;
-
-use std::fs;
-#[cfg(not(target_os = "windows"))]
-use std::path;
-
-#[cfg(not(target_os = "windows"))]
-use std::ffi::CString;
-#[cfg(not(target_os = "windows"))]
-use libc::statvfs;
-
-#[cfg(not(target_os = "windows"))]
-use alloc::heap;
-#[cfg(not(target_os = "windows"))]
-use core::mem::size_of;
 
 use std::sync::Mutex;
 
 lazy_static! {
- static ref ENV: Arc<lmdb::Environment> = {
-     let _ = config::set_default("storage.path", "pumpkin.db");
 
-     let path = config::get_str("storage.path").unwrap().into_owned();
-     fs::create_dir_all(path.as_str()).expect("can't create directory");
-     unsafe {
-            let mut env_builder = lmdb::EnvBuilder::new()
-                .expect("can't create env builder");
-
-            // Configure map size
-            if !cfg!(target_os = "windows") && config::get_int("storage.mapsize").is_none() {
-                #[cfg(not(target_os = "windows"))]
-                {
-                    let path = path::PathBuf::from(path.as_str());
-                    let canonical = fs::canonicalize(&path).unwrap();
-                    let absolute_path = canonical.as_path().to_str().unwrap();
-                    let absolute_path_c = CString::new(absolute_path).unwrap();
-                    let statp: *mut statvfs = heap::allocate(size_of::<statvfs>(), size_of::<usize>()) as *mut statvfs;
-                    let mut stat = *statp;
-                    if statvfs(absolute_path_c.as_ptr(), &mut stat) != 0 {
-                       warn!("Can't determine available disk space");
-                    } else {
-                       let size = (stat.f_frsize * stat.f_bavail as u64) as usize;
-                       info!("Available disk space is approx. {}Gb, setting database map size to it", size / (1024*1024*1024));
-                       env_builder.set_mapsize(size).expect("can't set map size");
-                    }
-                    heap::deallocate(statp as *mut u8, size_of::<statvfs>(), size_of::<usize>());
-                }
-            } else {
-                match config::get_int("storage.mapsize") {
-                   Some(mapsize) => {
-                       env_builder.set_mapsize(1024 * mapsize as usize).expect("can't set map size");
-                   },
-                   None => {
-                       warn!("No default storage.mapsize set, setting it to 1Gb");
-                       env_builder.set_mapsize(1024 * 1024 * 1024).expect("can't set map size");
-                   }
-                }
-            }
-            Arc::new(env_builder
-                .open(path.as_str(), lmdb::open::Flags::empty(), 0o600)
-                .expect("can't open env"))
-    }
+ static ref ENVIRONMENT: lmdb::Environment = {
+    let _ = config::set_default("storage.path", "pumpkin.db");
+    let storage_path = config::get_str("storage.path").unwrap().into_owned();
+    fs::create_dir_all(storage_path.as_str()).expect("can't create directory");
+    let map_size = config::get_int("storage.mapsize");
+    storage::create_environment(storage_path, map_size)
  };
 
- static ref DATABASE: Arc<storage::Storage<'static>> = Arc::new(storage::Storage::new(&ENV));
+ static ref DATABASE: Arc<storage::Storage<'static>> = {
+    Arc::new(storage::Storage::new(&ENVIRONMENT))
+ };
 
  static ref PUBLISHER: Mutex<pubsub::PublisherAccessor<Vec<u8>>> = {
      let mut publisher = pubsub::Publisher::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,6 @@ fn main() {
     for i in 0..num_cpus::get() {
         info!("Starting scheduler on core {}.", i);
         let mut scheduler = script::Scheduler::new(
-            &ENV,
             &DATABASE,
             PUBLISHER.lock().unwrap().clone(),
         );

--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -248,10 +248,7 @@ macro_rules! eval {
                     .expect("can't open env")
             };
 
-            let db = lmdb::Database::open(&env,
-                                 None,
-                                 &lmdb::DatabaseOptions::new(lmdb::db::CREATE))
-                                 .expect("can't open database");
+            let db = database::Database::new(&env);
             crossbeam::scope(|scope| {
                 let mut publisher = pubsub::Publisher::new();
                 let $publisher_accessor = publisher.accessor();
@@ -317,10 +314,7 @@ macro_rules! bench_eval {
                     .expect("can't open env")
             };
 
-            let db = lmdb::Database::open(&env,
-                                 None,
-                                 &lmdb::DatabaseOptions::new(lmdb::db::CREATE))
-                                 .expect("can't open database");
+            let db = database::Database::new(&env);
             crossbeam::scope(|scope| {
                 let mut publisher = pubsub::Publisher::new();
                 let publisher_accessor = publisher.accessor();

--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -248,7 +248,7 @@ macro_rules! eval {
                     .expect("can't open env")
             };
 
-            let db = database::Database::new(&env);
+            let db = storage::Storage::new(&env);
             crossbeam::scope(|scope| {
                 let mut publisher = pubsub::Publisher::new();
                 let $publisher_accessor = publisher.accessor();
@@ -314,7 +314,7 @@ macro_rules! bench_eval {
                     .expect("can't open env")
             };
 
-            let db = database::Database::new(&env);
+            let db = storage::Storage::new(&env);
             crossbeam::scope(|scope| {
                 let mut publisher = pubsub::Publisher::new();
                 let publisher_accessor = publisher.accessor();

--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -254,7 +254,7 @@ macro_rules! eval {
                 let $publisher_accessor = publisher.accessor();
                 let publisher_thread = scope.spawn(move || publisher.run());
                 $($init)*
-                let mut scheduler = Scheduler::new(&env, &db, $publisher_accessor.clone());
+                let mut scheduler = Scheduler::new(&db, $publisher_accessor.clone());
                 let sender = scheduler.sender();
                 let handle = scope.spawn(move || {
                     scheduler.run();
@@ -320,7 +320,7 @@ macro_rules! bench_eval {
                 let publisher_accessor = publisher.accessor();
                 let publisher_accessor_ = publisher.accessor();
                 let publisher_thread = scope.spawn(move || publisher.run());
-                let mut scheduler = Scheduler::new(&env, &db, publisher_accessor.clone());
+                let mut scheduler = Scheduler::new(&db, publisher_accessor.clone());
                 let sender = scheduler.sender();
                 let sender_ = sender.clone();
                 let handle = scope.spawn(move || {

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -62,6 +62,7 @@
 use std::collections::BTreeMap;
 
 pub mod envheap;
+
 use self::envheap::EnvHeap;
 
 /// `word!` macro is used to define a built-in word, its signature (if applicable)
@@ -313,6 +314,7 @@ pub enum ResponseMessage {
 pub type TrySendError<T> = std::sync::mpsc::TrySendError<T>;
 
 use lmdb;
+use database;
 
 use pubsub;
 
@@ -457,7 +459,8 @@ impl<'a> Scheduler<'a> {
     /// * Response sender
     /// * Internal sender
     /// * Request receiver
-    pub fn new(db_env: &'a lmdb::Environment, db: &'a lmdb::Database<'a>,
+    pub fn new(db_env: &'a lmdb::Environment,
+               db: &'a database::Database<'a>,
                publisher: pubsub::PublisherAccessor<Vec<u8>>) -> Self {
         let (sender, receiver) = mpsc::channel::<RequestMessage>();
         #[cfg(not(feature = "static_module_dispatch"))]
@@ -708,6 +711,7 @@ mod tests {
     use crossbeam;
     use super::binparser;
     use pubsub;
+    use database;
 
     const _EMPTY: &'static [u8] = b"";
 

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -313,7 +313,6 @@ pub enum ResponseMessage {
 
 pub type TrySendError<T> = std::sync::mpsc::TrySendError<T>;
 
-use lmdb;
 use storage;
 
 use pubsub;
@@ -459,8 +458,7 @@ impl<'a> Scheduler<'a> {
     /// * Response sender
     /// * Internal sender
     /// * Request receiver
-    pub fn new(db_env: &'a lmdb::Environment,
-               db: &'a storage::Storage<'a>,
+    pub fn new(db: &'a storage::Storage<'a>,
                publisher: pubsub::PublisherAccessor<Vec<u8>>) -> Self {
         let (sender, receiver) = mpsc::channel::<RequestMessage>();
         #[cfg(not(feature = "static_module_dispatch"))]
@@ -471,7 +469,7 @@ impl<'a> Scheduler<'a> {
                           Box::new(mod_stack::Handler::new()),
                           Box::new(mod_binaries::Handler::new()),
                           Box::new(mod_numbers::Handler::new()),
-                          Box::new(mod_storage::Handler::new(db_env, db)),
+                          Box::new(mod_storage::Handler::new(db)),
                           Box::new(mod_hash::Handler::new()),
                           Box::new(mod_hlc::Handler::new()),
                           Box::new(mod_json::Handler::new()),
@@ -485,7 +483,7 @@ impl<'a> Scheduler<'a> {
             stack: mod_stack::Handler::new(),
             binaries: mod_binaries::Handler::new(),
             numbers: mod_numbers::Handler::new(),
-            storage: mod_storage::Handler::new(db_env, db),
+            storage: mod_storage::Handler::new(db),
             hash: mod_hash::Handler::new(),
             hlc: mod_hlc::Handler::new(),
             json: mod_json::Handler::new()

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -314,7 +314,7 @@ pub enum ResponseMessage {
 pub type TrySendError<T> = std::sync::mpsc::TrySendError<T>;
 
 use lmdb;
-use database;
+use storage;
 
 use pubsub;
 
@@ -460,7 +460,7 @@ impl<'a> Scheduler<'a> {
     /// * Internal sender
     /// * Request receiver
     pub fn new(db_env: &'a lmdb::Environment,
-               db: &'a database::Database<'a>,
+               db: &'a storage::Storage<'a>,
                publisher: pubsub::PublisherAccessor<Vec<u8>>) -> Self {
         let (sender, receiver) = mpsc::channel::<RequestMessage>();
         #[cfg(not(feature = "static_module_dispatch"))]
@@ -711,7 +711,7 @@ mod tests {
     use crossbeam;
     use super::binparser;
     use pubsub;
-    use database;
+    use storage;
 
     const _EMPTY: &'static [u8] = b"";
 

--- a/src/script/mod_core.rs
+++ b/src/script/mod_core.rs
@@ -397,7 +397,7 @@ mod tests {
     use crossbeam;
     use super::binparser;
     use pubsub;
-    use database;
+    use storage;
 
     const _EMPTY: &'static [u8] = b"";
 

--- a/src/script/mod_core.rs
+++ b/src/script/mod_core.rs
@@ -397,6 +397,7 @@ mod tests {
     use crossbeam;
     use super::binparser;
     use pubsub;
+    use database;
 
     const _EMPTY: &'static [u8] = b"";
 

--- a/src/script/mod_storage.rs
+++ b/src/script/mod_storage.rs
@@ -11,8 +11,8 @@
 //!
 use lmdb;
 use lmdb::traits::LmdbResultExt;
-use database;
-use database::GlobalWriteLock;
+use storage;
+use storage::GlobalWriteLock;
 use std::mem;
 use std::error::Error as StdError;
 use std::collections::HashMap;
@@ -59,7 +59,7 @@ enum TxType {
 }
 
 pub struct Handler<'a> {
-    db: &'a database::Database<'a>,
+    db: &'a storage::Storage<'a>,
     db_env: &'a lmdb::Environment,
     db_write_txn: Option<(EnvId, lmdb::WriteTransaction<'a>)>,
     db_read_txns: HashMap<EnvId, lmdb::ReadTransaction<'a>>,
@@ -230,7 +230,7 @@ impl<'a> Module<'a> for Handler<'a> {
 impl<'a> Handler<'a> {
 
     pub fn new(db_env: &'a lmdb::Environment,
-               db: &'a database::Database<'a>) -> Self {
+               db: &'a storage::Storage<'a>) -> Self {
         Handler {
             db: db,
             db_env: db_env,
@@ -510,7 +510,7 @@ mod tests {
     use crossbeam;
     use script::binparser;
     use pubsub;
-    use database;
+    use storage;
 
     const _EMPTY: &'static [u8] = b"";
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,7 +4,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 use script;
 
 use mio::*;
@@ -16,7 +15,7 @@ use self::server::*;
 
 use pubsub;
 
-pub fn run(port: i64, sender: script::Sender<script::RequestMessage>,
+pub fn run(port: i64, senders: Vec<script::Sender<script::RequestMessage>>,
                         publisher: pubsub::PublisherAccessor<Vec<u8>>) {
     let addr = format!("0.0.0.0:{}", port).parse().unwrap();
 
@@ -26,7 +25,7 @@ pub fn run(port: i64, sender: script::Sender<script::RequestMessage>,
 
     let mut poll = Poll::new().expect("Failed to initialize polling");
 
-    let mut server = Server::new(sock, sender, publisher);
+    let mut server = Server::new(sock, senders, publisher);
     server.run(&mut poll).expect("Failed to run server");
 
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -33,7 +33,8 @@ use mio::channel as mio_chan;
 use std::collections::BTreeMap;
 
 pub struct Server {
-    sender: Sender<RequestMessage>,
+    senders: Vec<Sender<RequestMessage>>,
+    last_sender: usize,
     response_sender: Sender<ResponseMessage>,
     evented_sender: mio_chan::Sender<(Token, Vec<u8>, Vec<u8>)>,
     receiver: mio_chan::Receiver<(Token, Vec<u8>, Vec<u8>)>,
@@ -46,13 +47,14 @@ pub struct Server {
 
 
 impl Server {
-    pub fn new(sock: TcpListener, sender: Sender<RequestMessage>, publisher: pubsub::PublisherAccessor<Vec<u8>>) -> Server {
+    pub fn new(sock: TcpListener, senders: Vec<Sender<RequestMessage>>, publisher: pubsub::PublisherAccessor<Vec<u8>>) -> Server {
         let (response_sender, _) = mpsc::channel();
         let (evented_sender, receiver) = mio_chan::channel();
 
         Server {
             sock: sock,
-            sender: sender,
+            senders: senders,
+            last_sender: 0,
             response_sender: response_sender,
             evented_sender: evented_sender,
             receiver: receiver,
@@ -266,7 +268,6 @@ impl Server {
 
     fn readable(&mut self, token: Token) -> io::Result<()> {
         while let Some(mut message) = self.find_connection_by_token(token).readable()? {
-
             let id = EnvId::new();
             let mut vec = Vec::new();
             let mut subscribe = parse(format!("[{} 2 WRAP \"subscriptions\" SEND] 'SUBSCRIBE DEF", token.0).as_str()).unwrap();
@@ -274,7 +275,15 @@ impl Server {
             vec.append(&mut subscribe);
             vec.append(&mut unsubscribe);
             vec.append(&mut message);
-            let _ = self.sender.send(RequestMessage::ScheduleEnv(id, Vec::from(vec), self.response_sender.clone()));
+            if self.senders.len() - 1 > self.last_sender {
+                // This is a terrible way to balance load over senders. We need to move to something
+                // else, like round robin or random.
+                self.last_sender += 1;
+            } else {
+                self.last_sender = 0;
+            }
+            println!("Picking scheduler {}", self.last_sender);
+            let _ = self.senders.get(self.last_sender).unwrap().send(RequestMessage::ScheduleEnv(id, Vec::from(vec), self.response_sender.clone()));
 
         }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,7 +1,7 @@
 use std::sync::Mutex;
 use lmdb;
 
-pub struct Database<'a> {
+pub struct Storage<'a> {
     pub db: lmdb::Database<'a>,
     pub gwl: Mutex<()>
 }
@@ -10,18 +10,15 @@ pub trait GlobalWriteLock {
     fn try_lock(&self) -> bool;
 }
 
-impl<'a> GlobalWriteLock for Database<'a> {
+impl<'a> GlobalWriteLock for Storage<'a> {
     fn try_lock(&self) -> bool {
-        match self.gwl.try_lock() {
-            Ok(_) => true,
-            Err(_) => false
-        }
+        self.gwl.try_lock().is_ok()
     }
 }
 
-impl<'a> Database<'a> {
-    pub fn new(env: &'a lmdb::Environment) -> Database<'a> {
-        return Database {
+impl<'a> Storage<'a> {
+    pub fn new(env: &'a lmdb::Environment) -> Storage<'a> {
+        return Storage {
             db: lmdb::Database::open(env,
                                      None,
                                      &lmdb::DatabaseOptions::new(lmdb::db::CREATE))

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,9 +1,25 @@
+// Copyright (c) 2017, All Contributors (see CONTRIBUTORS file)
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+use std::fs;
+#[cfg(not(target_os = "windows"))]
+use std::path;
+#[cfg(not(target_os = "windows"))]
+use std::ffi::CString;
+#[cfg(not(target_os = "windows"))]
+use libc::statvfs;
+#[cfg(not(target_os = "windows"))]
+use alloc::heap;
+#[cfg(not(target_os = "windows"))]
+use core::mem::size_of;
 use std::sync::Mutex;
 use lmdb;
 
 pub struct Storage<'a> {
     pub db: lmdb::Database<'a>,
-    pub env: & 'a lmdb::Environment,
+    pub env: &'a lmdb::Environment,
     pub gwl: Mutex<()>
 }
 
@@ -19,13 +35,53 @@ impl<'a> GlobalWriteLock for Storage<'a> {
 
 impl<'a> Storage<'a> {
     pub fn new(env: &'a lmdb::Environment) -> Storage<'a> {
-        return Storage {
+        Storage {
             env: env,
-            db: lmdb::Database::open(env,
-                                     None,
+            db: lmdb::Database::open(env, None,
                                      &lmdb::DatabaseOptions::new(lmdb::db::CREATE))
-                .expect("can't open database"),
+            .expect("can't open database"),
             gwl: Mutex::new(())
         }
+    }
+}
+
+pub fn create_environment(storage_path: String, map_size: Option<i64>) -> lmdb::Environment {
+    unsafe {
+        let mut env_builder = lmdb::EnvBuilder::new()
+            .expect("can't create env builder");
+
+        // Configure map size
+        if !cfg!(target_os = "windows") && map_size.is_none() {
+            #[cfg(not(target_os = "windows"))]
+                {
+                    let path = path::PathBuf::from(storage_path.as_str());
+                    let canonical = fs::canonicalize(&path).unwrap();
+                    let absolute_path = canonical.as_path().to_str().unwrap();
+                    let absolute_path_c = CString::new(absolute_path).unwrap();
+                    let statp: *mut statvfs = heap::allocate(size_of::<statvfs>(), size_of::<usize>()) as *mut statvfs;
+                    let mut stat = *statp;
+                    if statvfs(absolute_path_c.as_ptr(), &mut stat) != 0 {
+                        warn!("Can't determine available disk space");
+                    } else {
+                        let size = (stat.f_frsize * stat.f_bavail as u64) as usize;
+                        info!("Available disk space is approx. {}Gb, setting database map size to it", size / (1024*1024*1024));
+                        env_builder.set_mapsize(size).expect("can't set map size");
+                    }
+                    heap::deallocate(statp as *mut u8, size_of::<statvfs>(), size_of::<usize>());
+                }
+        } else {
+            match map_size {
+                Some(mapsize) => {
+                    env_builder.set_mapsize(1024 * mapsize as usize).expect("can't set map size");
+                },
+                None => {
+                    warn!("No default storage.mapsize set, setting it to 1Gb");
+                    env_builder.set_mapsize(1024 * 1024 * 1024).expect("can't set map size");
+                }
+            }
+        }
+        env_builder
+            .open(storage_path.as_str(), lmdb::open::Flags::empty(), 0o600)
+            .expect("can't open env")
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3,6 +3,7 @@ use lmdb;
 
 pub struct Storage<'a> {
     pub db: lmdb::Database<'a>,
+    pub env: & 'a lmdb::Environment,
     pub gwl: Mutex<()>
 }
 
@@ -19,6 +20,7 @@ impl<'a> GlobalWriteLock for Storage<'a> {
 impl<'a> Storage<'a> {
     pub fn new(env: &'a lmdb::Environment) -> Storage<'a> {
         return Storage {
+            env: env,
             db: lmdb::Database::open(env,
                                      None,
                                      &lmdb::DatabaseOptions::new(lmdb::db::CREATE))


### PR DESCRIPTION
Solution: Start a scheduler for every core, and
add a dispatches (currently LIFO). Since LMDB has
a single writer, add a global write lock for now.

This is a work on progress. I'm opening a PR now to
get feedback on my the current path.