### PR TITLE
Problem: Using `0x01` and `0x00` in larger scripts to compare against booleans can look confusing.

### DIFF
--- a/src/script/builtins
+++ b/src/script/builtins
@@ -1,5 +1,7 @@
 ( Constants )
 $SYSTEM/VERSION : "0.2-wip".
+TRUE : 0x01.
+FALSE : 0x00.
 ( Basic built-ins )
 2DUP : OVER OVER.
 2DROP : DROP DROP.


### PR DESCRIPTION
Solution: Introduce `TRUE` and `FALSE` as built-in
shorthands.

Closes https://github.com/PumpkinDB/PumpkinDB/issues/145