### PR TITLE
Problem: Transaction commits can result in errors, which are currently being eaten.

### DIFF
--- a/src/script/mod_storage.rs
+++ b/src/script/mod_storage.rs
@@ -325,8 +325,10 @@ impl<'a> Handler<'a> {
         if word == COMMIT {
             validate_lockout!(env, self.db_write_txn, pid);
             if let Some((_, txn)) = mem::replace(&mut self.db_write_txn, None) {
-                let _ = txn.commit();
-                Ok(())
+                match txn.commit() {
+                    Ok(_) => Ok(()),
+                    Err(reason) => Err(error_database!(reason))
+                }
             } else {
                 Err(error_no_transaction!())
             }


### PR DESCRIPTION
Solution: Expose errors that happen while
committing a transaction.


https://github.com/PumpkinDB/PumpkinDB/issues/162