### PR TITLE
Fix SET Command example of the documentation which is currently not working.

### DIFF
--- a/doc/script/SET.md
+++ b/doc/script/SET.md
@@ -21,7 +21,7 @@ word referenced by top item (`w`)
 {% common -%}
 
 ```
-PumpkinDB> "key" key SET [`key "value" ASSOC COMMIT] WRITE [key RETR] READ
+PumpkinDB> "key" 'key SET [key "value" ASSOC COMMIT] WRITE [key RETR] READ
 "value"
 ```
 


### PR DESCRIPTION
## Problem:

```
PumpkinDB> "key" key SET [`key "value" ASSOC COMMIT] WRITE [key RETR] READ.
"key" Error: "Unknown word: key" 0x04836b6579 0x02
```

## Solution

```
PumpkinDB> "key" 'key SET [key "value" ASSOC COMMIT] WRITE [key RETR] READ.
"value"
```