### PR TITLE
Problem: Wrong example in documentation of HLC/LC

### DIFF
--- a/doc/script/HLC/LC.md
+++ b/doc/script/HLC/LC.md
@@ -14,8 +14,8 @@ its logical counter as a 4-byte big-endian number.
 {% common -%}
 
 ```
-PumpkinDB> HLC DUP HLC/TICK
-0x000014A278ED90AB13700000 0x000014A278ED90AB13700001
+PumpkinDB> HLC DUP HLC/LC SWAP HLC/TICK DUP HLC/LC SWAP HLC/TICK HLC/LC
+0x00000000 0x00000001 0x00000002
 ```
 
 {% endmethod %}


### PR DESCRIPTION
Problem: 

The example of LC does not talk about the command (copy/paste of the HLC/TICK command)
```
PumpkinDB> HLC DUP HLC/TICK
0x000014A278ED90AB13700000 0x000014A278ED90AB13700001
```
Solution: Use the HLC/LC command in the example, and also the HLC/TICK