### PR TITLE
Problem: multiple active readers per scheduler (thread) will fail

### DIFF
--- a/src/bin/pumpkindb-doctests.rs
+++ b/src/bin/pumpkindb-doctests.rs
@@ -37,7 +37,7 @@ fn eval(name: &[u8], script: &[u8]) {
     let env = unsafe {
         lmdb::EnvBuilder::new()
             .expect("can't create env builder")
-            .open(path, lmdb::open::Flags::empty(), 0o600)
+            .open(path, lmdb::open::NOTLS, 0o600)
             .expect("can't open env")
     };
     let name = String::from(std::str::from_utf8(name).unwrap());

--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -244,7 +244,7 @@ macro_rules! eval {
             let env = unsafe {
                 lmdb::EnvBuilder::new()
                     .expect("can't create env builder")
-                    .open(path, lmdb::open::Flags::empty(), 0o600)
+                    .open(path, lmdb::open::NOTLS, 0o600)
                     .expect("can't open env")
             };
 
@@ -310,7 +310,7 @@ macro_rules! bench_eval {
             let env = unsafe {
                 lmdb::EnvBuilder::new()
                     .expect("can't create env builder")
-                    .open(path, lmdb::open::Flags::empty(), 0o600)
+                    .open(path, lmdb::open::NOTLS, 0o600)
                     .expect("can't open env")
             };
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -35,6 +35,9 @@ impl<'a> GlobalWriteLock for Storage<'a> {
 
 impl<'a> Storage<'a> {
     pub fn new(env: &'a lmdb::Environment) -> Storage<'a> {
+        if !env.flags().unwrap().contains(lmdb::open::NOTLS) {
+            panic!("env should have NOTLS enabled");
+        }
         Storage {
             env: env,
             db: lmdb::Database::open(env, None,
@@ -81,7 +84,7 @@ pub fn create_environment(storage_path: String, map_size: Option<i64>) -> lmdb::
             }
         }
         env_builder
-            .open(storage_path.as_str(), lmdb::open::Flags::empty(), 0o600)
+            .open(storage_path.as_str(), lmdb::open::NOTLS, 0o600)
             .expect("can't open env")
     }
 }


### PR DESCRIPTION
This is my fault, this completely escaped my mind recently, but the reader
table in lmdb binds readers to their originating thread. The failure code:
http://www.lmdb.tech/doc/group__errors.html#ga1b6cbb28da30e28c48c9df66dd398bf0

Read more: http://www.lmdb.tech/doc/group__readers.html

Solution: use NOTLS flag (that doesn't use thread local storage)

Closes #177

**NB: I am not sure how to test this properly** 