### PR TITLE
Problem: write_1000_kv_pairs_in_isolated_txns fails exceeeding mapsize

### DIFF
--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -308,10 +308,9 @@ macro_rules! bench_eval {
             let path = dir.path().to_str().unwrap();
             fs::create_dir_all(path).expect("can't create directory");
             let env = unsafe {
-                lmdb::EnvBuilder::new()
-                    .expect("can't create env builder")
-                    .open(path, lmdb::open::NOTLS, 0o600)
-                    .expect("can't open env")
+                let mut builder = lmdb::EnvBuilder::new().expect("can't create env builder");
+                builder.set_mapsize(1024 * 1024 * 1024).expect("can't set mapsize");
+                builder.open(path, lmdb::open::NOTLS, 0o600).expect("can't open env")
             };
 
             let db = storage::Storage::new(&env);


### PR DESCRIPTION
Solution: increase the default mapsize for benchmarks to 1Gb.

Turns out, we have been testing it all wrong all. Since previously
commit errors were ignored, the timing we were getting was only for
a portion of writes. I actually noticed this discrepancy before when
I saw that benchmark-projected numbers didn't hold true when testing
large-scale writes in pumpkindb-term, but I didn't find a reason for that.

Well, ignoring errors while benchmarking was the reason!

And indeed, the numbers I was getting from benchmarking were not
exactly realistic. I was getting 8ms per 1000 writes, which is like
125,000 transactions per second. The measurements I've got from
other sources for lmdb were much lower.

So, once the mapsize issue was handled, the benchmark stopped failing
but (of course) produced very different results:

```
test script::mod_storage::tests::write_1000_kv_pairs_in_isolated_txns          ... bench: 174,469,794 ns/iter (+/- 24,788,947)
```

About 20 times slower. About 175ms per 1000 transactions. About 5,700 txn/sec.
Now this is realistic. Not as great, but realistic :)

In order to see how much overhead we're introducing, I wrote a baseline
benchmark that does the same but directly through lmdb API:

```
test script::mod_storage::tests::write_1000_kv_pairs_in_isolated_txns_baseline ... bench: 172,897,985 ns/iter (+/- 23,567,901)
```

So, if there no flaws in this benchmark, it means that in this particular
case our overhead is minimal, which is great (assuming the overhead of lmdb
libraries for Rust is also minimal)