### PR TITLE
Problem: HLC invariants can be broken (#32) and too much use of static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ serde_json = "0.9.8"
 clap = "2.20.5"
 num_cpus = "1.3.0"
 rand = "0.3.15"
+memmap = "0.5.2"
 
 [dev-dependencies]
 quickcheck = "0.4.1"

--- a/src/bin/pumpkindb-doctests.rs
+++ b/src/bin/pumpkindb-doctests.rs
@@ -50,17 +50,16 @@ fn eval(name: &[u8], script: &[u8]) {
         let publisher_thread = scope.spawn(move || publisher.run());
         let publisher_clone = publisher_accessor.clone();
         let timestamp_clone = timestamp.clone();
-        let (sender_sender, receiver) = mpsc::sync_channel(0);
+        let (sender, receiver) = Scheduler::create_sender();
         let handle = scope.spawn(move || {
             let mut scheduler = Scheduler::new(
                 &db,
                 publisher_clone,
                 timestamp_clone,
-                sender_sender,
+                receiver,
             );
             scheduler.run()
         });
-        let sender = receiver.recv().unwrap();
         let (callback, receiver) = mpsc::channel::<ResponseMessage>();
         let _ = sender.send(RequestMessage::ScheduleEnv(EnvId::new(), Vec::from(script), callback));
         match receiver.recv() {

--- a/src/bin/pumpkindb-doctests.rs
+++ b/src/bin/pumpkindb-doctests.rs
@@ -44,7 +44,7 @@ fn eval(name: &[u8], script: &[u8]) {
     let name = String::from(std::str::from_utf8(name).unwrap());
     let db = storage::Storage::new(&env);
     crossbeam::scope(|scope| {
-        let timestamp = Arc::new(timestamp::Timestamp::new());
+        let timestamp = Arc::new(timestamp::Timestamp::new(None));
         let mut publisher = pubsub::Publisher::new();
         let publisher_accessor = publisher.accessor();
         let publisher_thread = scope.spawn(move || publisher.run());

--- a/src/crates.rs
+++ b/src/crates.rs
@@ -49,3 +49,5 @@ extern crate rand;
 
 #[macro_use]
 extern crate log;
+
+extern crate memmap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ include!("crates.rs");
 
 pub mod script;
 #[allow(dead_code)]
-mod timestamp;
-#[allow(dead_code)]
 pub mod pubsub;
 pub mod storage;
+pub mod timestamp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,9 @@ lazy_static! {
 /// Accepts storage path, filename and length and prepares the file. It is important that the length
 /// is the total length of the memory mapped file, otherwise the application _will segfault_ when
 /// trying to read those sections later. There is no way to handle that.
+/// The mmap file is structured as such now:
+/// Byte Range         Used for
+/// [0..20]            Last known HTC timestamp
 fn prepare_mmap(storage_path: &str, filename: &str, length: u64) -> Mmap {
     let mut scratchpad_pathbuf = PathBuf::from(storage_path);
     scratchpad_pathbuf.push(filename);

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,17 +71,20 @@ fn main() {
     let publisher_accessor = publisher.accessor();
     let _ = thread::spawn(move || publisher.run());
     let storage = Arc::new(storage::Storage::new(&ENVIRONMENT));
+    let timestamp = Arc::new(timestamp::Timestamp::new());
 
     for i in 0..num_cpus::get() {
         info!("Starting scheduler on core {}.", i);
         let (sender, receiver) = mpsc::sync_channel(0);
         let publisher_clone = publisher_accessor.clone();
         let storage_clone = storage.clone();
+        let timestamp_clone = timestamp.clone();
         thread::spawn(move || {
             let mut scheduler = script::Scheduler::new(
                 &storage_clone,
                 publisher_clone,
-                sender
+                timestamp_clone,
+                sender,
             );
             scheduler.run()
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,6 @@ use std::fs::{OpenOptions};
 use std::path::PathBuf;
 use std::thread;
 use std::sync::Arc;
-use std::sync::mpsc;
 use memmap::{Mmap, Protection};
 
 lazy_static! {
@@ -100,7 +99,7 @@ fn main() {
 
     for i in 0..num_cpus::get() {
         info!("Starting scheduler on core {}.", i);
-        let (sender, receiver) = mpsc::sync_channel(0);
+        let (sender, receiver) = script::Scheduler::create_sender();
         let publisher_clone = publisher_accessor.clone();
         let storage_clone = storage.clone();
         let timestamp_clone = timestamp.clone();
@@ -109,11 +108,10 @@ fn main() {
                 &storage_clone,
                 publisher_clone,
                 timestamp_clone,
-                sender,
+                receiver,
             );
             scheduler.run()
         });
-        let sender = receiver.recv().expect("Could not receive sender");
         senders.push(sender)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ fn prepare_mmap(storage_path: &str, filename: &str, length: u64) -> Mmap {
     scratchpad_pathbuf.push(filename);
     scratchpad_pathbuf.set_extension("dat");
     let scratchpad_path = scratchpad_pathbuf.as_path();
-    let scratchpad_file = OpenOptions::new().create_new(false).write(true)
+    let scratchpad_file = OpenOptions::new().create(true).write(true)
         .open(scratchpad_path).expect("Could not open or create scratchpad");
     let _ = scratchpad_file.set_len(length);
     Mmap::open_path(scratchpad_path, Protection::ReadWrite)

--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -257,16 +257,15 @@ macro_rules! eval {
                 $($init)*
                 let publisher_clone = $publisher_accessor.clone();
                 let timestamp_clone = timestamp.clone();
-                let (sender_sender, receiver) = mpsc::sync_channel(0);
+                let (sender, receiver) = Scheduler::create_sender();
                 let handle = scope.spawn(move || {
                     let mut scheduler = Scheduler::new(
                         &db,
                         publisher_clone,
                         timestamp_clone,
-                        sender_sender);
+                        receiver);
                     scheduler.run()
                 });
-                let sender = receiver.recv().unwrap();
                 let script = parse($script).unwrap();
                 let (callback, receiver) = mpsc::channel::<ResponseMessage>();
                 let _ = sender.send(RequestMessage::ScheduleEnv(EnvId::new(),
@@ -330,17 +329,16 @@ macro_rules! bench_eval {
                 let publisher_thread = scope.spawn(move || publisher.run());
                 let publisher_clone = publisher_accessor.clone();
                 let timestamp_clone = timestamp.clone();
-                let (sender_sender, receiver) = mpsc::sync_channel(0);
+                let (sender, receiver) = Scheduler::create_sender();
                 let handle = scope.spawn(move || {
                     let mut scheduler = Scheduler::new(
                         &db,
                         publisher_clone,
                         timestamp_clone,
-                        sender_sender,
+                        receiver,
                     );
                     scheduler.run()
                 });
-                let sender = receiver.recv().unwrap();
                 let sender_ = sender.clone();
                 let script = parse($script).unwrap();
                 $b.iter(move || {

--- a/src/script/macros.rs
+++ b/src/script/macros.rs
@@ -250,7 +250,7 @@ macro_rules! eval {
 
             let db = storage::Storage::new(&env);
             crossbeam::scope(|scope| {
-                let timestamp = Arc::new(timestamp::Timestamp::new());
+                let timestamp = Arc::new(timestamp::Timestamp::new(None));
                 let mut publisher = pubsub::Publisher::new();
                 let $publisher_accessor = publisher.accessor();
                 let publisher_thread = scope.spawn(move || publisher.run());
@@ -324,7 +324,7 @@ macro_rules! bench_eval {
             let db = storage::Storage::new(&env);
             crossbeam::scope(|scope| {
                 let mut publisher = pubsub::Publisher::new();
-                let timestamp = Arc::new(timestamp::Timestamp::new());
+                let timestamp = Arc::new(timestamp::Timestamp::new(None));
                 let publisher_accessor = publisher.accessor();
                 let publisher_accessor_ = publisher.accessor();
                 let publisher_thread = scope.spawn(move || publisher.run());

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -463,9 +463,7 @@ impl<'a> Scheduler<'a> {
         db: &'a storage::Storage<'a>,
         publisher: pubsub::PublisherAccessor<Vec<u8>>,
         timestamp_state: Arc<timestamp::Timestamp>,
-        sender_sender: mpsc::SyncSender<Sender<RequestMessage>>) -> Self {
-        let (sender, receiver) = mpsc::channel::<RequestMessage>();
-        let _  = sender_sender.send(sender.clone());
+        receiver: Receiver<RequestMessage>) -> Self {
         #[cfg(not(feature = "static_module_dispatch"))]
         return Scheduler {
             inbox: receiver,
@@ -491,6 +489,10 @@ impl<'a> Scheduler<'a> {
             hlc: mod_hlc::Handler::new(timestamp_state),
             json: mod_json::Handler::new()
         };
+    }
+
+    pub fn create_sender() -> (Sender<RequestMessage>, Receiver<RequestMessage>) {
+        mpsc::channel::<RequestMessage>()
     }
 
     /// Scheduler. It is supposed to be running in a separate thread

--- a/src/script/mod_core.rs
+++ b/src/script/mod_core.rs
@@ -390,6 +390,7 @@ mod tests {
 
     use script::{Env, Scheduler, Error, RequestMessage, ResponseMessage, EnvId, parse, offset_by_size};
     use std::sync::mpsc;
+    use std::sync::Arc;
     use std::fs;
     use std::thread;
     use tempdir::TempDir;
@@ -398,6 +399,7 @@ mod tests {
     use super::binparser;
     use pubsub;
     use storage;
+    use timestamp;
 
     const _EMPTY: &'static [u8] = b"";
 

--- a/src/script/mod_storage.rs
+++ b/src/script/mod_storage.rs
@@ -548,7 +548,7 @@ mod tests {
             builder.set_mapsize(1024 * 1024 * 1024).expect("can't set mapsize");
             builder.open(path, lmdb::open::NOTLS, 0o600).expect("can't open env")
         };
-        let timestamp = timestamp::Timestamp::new();
+        let timestamp = timestamp::Timestamp::new(None);
         let db = storage::Storage::new(&env);
         b.iter(move || {
             let mut timestamps = Vec::new();

--- a/src/script/mod_storage.rs
+++ b/src/script/mod_storage.rs
@@ -500,7 +500,9 @@ impl<'a> Handler<'a> {
 #[allow(unused_variables, unused_must_use, unused_mut, unused_imports)]
 mod tests {
     use script::{Env, Scheduler, Error, RequestMessage, ResponseMessage, EnvId, parse, offset_by_size};
+    use byteorder::WriteBytesExt;
     use std::sync::mpsc;
+    use std::sync::Arc;
     use std::fs;
     use tempdir::TempDir;
     use lmdb;
@@ -508,6 +510,7 @@ mod tests {
     use script::binparser;
     use pubsub;
     use storage;
+    use timestamp;
 
     const _EMPTY: &'static [u8] = b"";
 
@@ -535,9 +538,6 @@ mod tests {
         bench_eval!("[HLC \"Hello\"] 1000 TIMES [[ASSOC COMMIT] WRITE] 1000 TIMES", b);
     }
 
-    use timestamp;
-    use byteorder::WriteBytesExt;
-
     #[bench]
     fn write_1000_kv_pairs_in_isolated_txns_baseline(b: &mut Bencher) {
         let dir = TempDir::new("pumpkindb").unwrap();
@@ -548,12 +548,12 @@ mod tests {
             builder.set_mapsize(1024 * 1024 * 1024).expect("can't set mapsize");
             builder.open(path, lmdb::open::NOTLS, 0o600).expect("can't open env")
         };
-
+        let timestamp = timestamp::Timestamp::new();
         let db = storage::Storage::new(&env);
         b.iter(move || {
             let mut timestamps = Vec::new();
             for i in 0..1000 {
-                timestamps.push(timestamp::hlc());
+                timestamps.push(timestamp.hlc());
             }
             for ts in timestamps {
                 let txn = lmdb::WriteTransaction::new(db.env).unwrap();

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -6,21 +6,50 @@
 
 use hlc;
 use std::sync::Mutex;
+use memmap::{MmapViewSync, Mmap, Protection};
 
 #[derive(Debug)]
 pub struct Timestamp {
-    clock: Mutex<hlc::Clock<hlc::Wall>>
+    clock: Mutex<(hlc::Clock<hlc::Wall>, MmapViewSync)>,
 }
 
 impl Timestamp {
-    pub fn new() -> Self {
-        Timestamp {
-            clock: Mutex::new(hlc::Clock::wall())
+    /// Create a new Timestamp clock. First the passed in memory map will be checked to check if
+    /// a previous timestamp exists. If one exists (i.e. if the results aren't 20 bytes of 0) it
+    /// will be "observed" by the HLC library.
+    pub fn new(scratchpad: Option<MmapViewSync>) -> Self {
+        if scratchpad.is_some() {
+            let scratchpad = scratchpad.unwrap();
+            let clock = {
+                let mut clock = hlc::Clock::wall();
+                let previous = unsafe { scratchpad.as_slice() };
+                let res = hlc::Timestamp::read_bytes(previous);
+                if res.is_ok() {
+                    let res = res.unwrap();
+                    if res > clock.now() {
+                        let _ = clock.observe(&res);
+                    }
+                }
+                clock
+            };
+            Timestamp {
+                clock: Mutex::new((clock, scratchpad)),
+            }
+        } else {
+            let clock = hlc::Clock::wall();
+            let scratchpad = Mmap::anonymous(20, Protection::ReadWrite).unwrap();
+            Timestamp {
+                clock: Mutex::new((clock, scratchpad.into_view_sync()))
+            }
         }
     }
 
     pub fn hlc(&self) -> hlc::Timestamp<hlc::WallT> {
-        self.clock.lock().unwrap().now()
+        let mut clock = self.clock.lock().unwrap();
+        let now = clock.0.now();
+        let ref mut state = clock.1;
+        let _ = unsafe { &now.write_bytes(&mut state.as_mut_slice()).unwrap() };
+        now
     }
 
 }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -7,25 +7,20 @@
 use hlc;
 use std::sync::Mutex;
 
-lazy_static! {
-
-   static ref HLC_CLOCK: Mutex<hlc::Clock<hlc::Wall>> = Mutex::new(hlc::Clock::wall());
-
+#[derive(Debug)]
+pub struct Timestamp {
+    clock: Mutex<hlc::Clock<hlc::Wall>>
 }
 
-pub fn hlc() -> hlc::Timestamp<hlc::WallT> {
-    (*HLC_CLOCK).lock().unwrap().now()
-}
-
-#[cfg(test)]
-mod tests {
-
-    use timestamp;
-
-    #[test]
-    fn test() {
-        let t1 = timestamp::hlc();
-        let t2 = timestamp::hlc();
-        assert!(t2 > t1);
+impl Timestamp {
+    pub fn new() -> Self {
+        Timestamp {
+            clock: Mutex::new(hlc::Clock::wall())
+        }
     }
+
+    pub fn hlc(&self) -> hlc::Timestamp<hlc::WallT> {
+        self.clock.lock().unwrap().now()
+    }
+
 }


### PR DESCRIPTION
Solution: This PR introduces a memory mapped meta database that is used by modules to persist whatever state they might need to reconstruct their previous state after a restart. For now this is only done for HLCs (see 77b2506).

Additionally, remove excessive usage of `lazy_static` (06e1156, 5200d65, 4c7065f).