### PR TITLE
Problem: Read/Write Transaction algorithm is incorrect

### DIFF
--- a/doc/script/CURSOR/CURQ.md
+++ b/doc/script/CURSOR/CURQ.md
@@ -35,6 +35,6 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ```test
 works : ["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c ?CURSOR/FIRST DROP c CURSOR/CUR?] READ.
 requires_txn : ["1" CURSOR/CUR?] TRY UNWRAP 0x08 EQUAL?.
-empty_stack : [CURSOR/CUR?] TRY UNWRAP 0x04 EQUAL?.
+empty_stack : [[CURSOR/CUR?] TRY] READ UNWRAP 0x04 EQUAL?.
 invalid_cursor : [["1" CURSOR/CUR?] READ] TRY UNWRAP 0x03 EQUAL?.
 ```

--- a/doc/script/CURSOR/FIRSTQ.md
+++ b/doc/script/CURSOR/FIRSTQ.md
@@ -37,6 +37,6 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ```test
 works : ["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/FIRST?] READ.
 requires_txn : ["1" CURSOR/FIRST?] TRY UNWRAP 0x08 EQUAL?.
-empty_stack : [CURSOR/FIRST?] TRY UNWRAP 0x04 EQUAL?.
+empty_stack : [[CURSOR/FIRST?] TRY] READ UNWRAP 0x04 EQUAL?.
 invalid_cursor : [["1" CURSOR/FIRST?] READ] TRY UNWRAP 0x03 EQUAL?.
 ```

--- a/doc/script/CURSOR/LASTQ.md
+++ b/doc/script/CURSOR/LASTQ.md
@@ -37,6 +37,6 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ```test
 works : ["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c CURSOR/LAST?] READ.
 requires_txn : ["1" CURSOR/LAST?] TRY UNWRAP 0x08 EQUAL?.
-empty_stack : [CURSOR/LAST?] TRY UNWRAP 0x04 EQUAL?.
+empty_stack : [[CURSOR/LAST?] TRY] READ UNWRAP 0x04 EQUAL?.
 invalid_cursor : [["1" CURSOR/LAST?] READ] TRY UNWRAP 0x03 EQUAL?.
 ```

--- a/doc/script/CURSOR/NEXTQ.md
+++ b/doc/script/CURSOR/NEXTQ.md
@@ -37,6 +37,6 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ```test
 works : ["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c ?CURSOR/FIRST DROP c CURSOR/NEXT?] READ.
 requires_txn : ["1" CURSOR/NEXT?] TRY UNWRAP 0x08 EQUAL?.
-empty_stack : [CURSOR/NEXT?] TRY UNWRAP 0x04 EQUAL?.
+empty_stack : [[CURSOR/NEXT?] TRY] READ UNWRAP 0x04 EQUAL?.
 invalid_cursor : [["1" CURSOR/NEXT?] READ] TRY UNWRAP 0x03 EQUAL?.
 ```

--- a/doc/script/CURSOR/PREVQ.md
+++ b/doc/script/CURSOR/PREVQ.md
@@ -37,6 +37,6 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ```test
 works : ["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c ?CURSOR/LAST DROP c CURSOR/PREV?] READ.
 requires_txn : ["1" CURSOR/PREV?] TRY UNWRAP 0x08 EQUAL?.
-empty_stack : [CURSOR/PREV?] TRY UNWRAP 0x04 EQUAL?.
+empty_stack : [[CURSOR/PREV?] TRY] READ UNWRAP 0x04 EQUAL?. 
 invalid_cursor : [["1" CURSOR/PREV?] READ] TRY UNWRAP 0x03 EQUAL?.
 ```

--- a/doc/script/CURSOR/SEEKQ.md
+++ b/doc/script/CURSOR/SEEKQ.md
@@ -39,6 +39,6 @@ InvalidValue error if the cursor identifier is incorrect or expired
 works : ["3" "3" ASSOC COMMIT] WRITE [CURSOR 'c SET c "2" CURSOR/SEEK?] READ.
 requires_txn : ["1" "1" CURSOR/SEEK?] TRY UNWRAP 0x08 EQUAL?.
 empty_stack : [CURSOR/SEEK?] TRY UNWRAP 0x04 EQUAL?.
-empty_stack_1 : ["a" CURSOR/SEEK?] TRY UNWRAP 0x04 EQUAL?.
+empty_stack_1 : [["a" CURSOR/SEEK?] TRY] READ UNWRAP 0x04 EQUAL?.
 invalid_cursor : [["1" "A" CURSOR/SEEK?] READ] TRY UNWRAP 0x03 EQUAL?.
 ```

--- a/doc/script/QCURSOR/CUR.md
+++ b/doc/script/QCURSOR/CUR.md
@@ -38,6 +38,6 @@ Allocates for values to be put onto the stack
 ```test
 works : ["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c ?CURSOR/FIRST DROP c ?CURSOR/CUR] READ ["1" "2"] EQUAL?.
 requires_txn : ["1" ?CURSOR/CUR] TRY UNWRAP 0x08 EQUAL?.
-empty_stack : [?CURSOR/CUR] TRY UNWRAP 0x04 EQUAL?.
+empty_stack : [[?CURSOR/CUR] TRY] READ UNWRAP 0x04 EQUAL?.
 invalid_cursor : [["1" ?CURSOR/CUR] READ] TRY UNWRAP 0x03 EQUAL?.
 ```

--- a/doc/script/QCURSOR/FIRST.md
+++ b/doc/script/QCURSOR/FIRST.md
@@ -36,6 +36,6 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ```test
 works : ["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c ?CURSOR/FIRST] READ ["1" "2"] EQUAL?.
 requires_txn : ["1" ?CURSOR/FIRST] TRY UNWRAP 0x08 EQUAL?.
-empty_stack : [?CURSOR/FIRST] TRY UNWRAP 0x04 EQUAL?.
+empty_stack : [[?CURSOR/FIRST] TRY] READ UNWRAP 0x04 EQUAL?.
 invalid_cursor : [["1" ?CURSOR/FIRST] READ] TRY UNWRAP 0x03 EQUAL?.
 ```

--- a/doc/script/QCURSOR/LAST.md
+++ b/doc/script/QCURSOR/LAST.md
@@ -36,6 +36,6 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ```test
 works : ["1" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c ?CURSOR/LAST] READ ["1" "2"] EQUAL?.
 requires_txn : ["1" ?CURSOR/LAST] TRY UNWRAP 0x08 EQUAL?.
-empty_stack : [?CURSOR/LAST] TRY UNWRAP 0x04 EQUAL?.
+empty_stack : [[?CURSOR/LAST] TRY] READ UNWRAP 0x04 EQUAL?.
 invalid_cursor : [["1" ?CURSOR/LAST] READ] TRY UNWRAP 0x03 EQUAL?.
 ```

--- a/doc/script/QCURSOR/NEXT.md
+++ b/doc/script/QCURSOR/NEXT.md
@@ -36,6 +36,6 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ```test
 works : ["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c ?CURSOR/FIRST DROP c ?CURSOR/NEXT] READ ["2" "2"] EQUAL?.
 requires_txn : ["1" ?CURSOR/NEXT] TRY UNWRAP 0x08 EQUAL?.
-empty_stack : [?CURSOR/NEXT] TRY UNWRAP 0x04 EQUAL?.
+empty_stack : [[?CURSOR/NEXT] TRY] READ UNWRAP 0x04 EQUAL?.
 invalid_cursor : [["1" ?CURSOR/NEXT] READ] TRY UNWRAP 0x03 EQUAL?.
 ```

--- a/doc/script/QCURSOR/PREV.md
+++ b/doc/script/QCURSOR/PREV.md
@@ -35,6 +35,6 @@ InvalidValue error if the cursor identifier is incorrect or expired
 ```test
 works : ["1" "2" ASSOC "2" "2" ASSOC COMMIT] WRITE [CURSOR 'c SET c ?CURSOR/LAST DROP c ?CURSOR/PREV] READ ["1" "2"] EQUAL?.
 requires_txn : ["1" ?CURSOR/PREV] TRY UNWRAP 0x08 EQUAL?.
-empty_stack : [?CURSOR/PREV] TRY UNWRAP 0x04 EQUAL?.
+empty_stack : [[?CURSOR/PREV] TRY] READ UNWRAP 0x04 EQUAL?.
 invalid_cursor : [["1" ?CURSOR/PREV] READ] TRY UNWRAP 0x03 EQUAL?.
 ```

--- a/doc/script/QCURSOR/SEEK.md
+++ b/doc/script/QCURSOR/SEEK.md
@@ -38,6 +38,6 @@ InvalidValue error if the cursor identifier is incorrect or expired
 works : ["3" "3" ASSOC COMMIT] WRITE [CURSOR 'c SET c "2" ?CURSOR/SEEK] READ ["3" "3"] EQUAL?.
 requires_txn : ["1" "1" ?CURSOR/SEEK] TRY UNWRAP 0x08 EQUAL?.
 empty_stack : [?CURSOR/SEEK] TRY UNWRAP 0x04 EQUAL?.
-empty_stack_1 : ["a" ?CURSOR/SEEK] TRY UNWRAP 0x04 EQUAL?.
+empty_stack_1 : [["a" ?CURSOR/SEEK] TRY] READ UNWRAP 0x04 EQUAL?.
 invalid_cursor : [["1" "A" ?CURSOR/SEEK] READ] TRY UNWRAP 0x03 EQUAL?.
 ```

--- a/doc/script/READ.md
+++ b/doc/script/READ.md
@@ -12,6 +12,8 @@ This instruction is one of two ways one can read from the database.
 Instructions like [RETR](RETR.md) are only possible in the context of
 a READ or a [WRITE](WRITE.md).
 
+The total number of transaction per environment is 64.
+
 {% common -%}
 
 ```

--- a/doc/script/WRITE.md
+++ b/doc/script/WRITE.md
@@ -14,6 +14,8 @@ a WRITE. If changes are to be saved, [COMMIT](COMMIT.md) has to be
 used as well. Read-transaction related instructions (such as [RETR](RETR.md))
 can also be used.
 
+The total number of transaction per environment is 64.
+
 {% common -%}
 
 ```

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -316,6 +316,7 @@ use storage;
 use timestamp;
 use pubsub;
 
+pub mod queue;
 pub mod mod_core;
 pub mod mod_stack;
 pub mod mod_numbers;

--- a/src/script/mod_storage.rs
+++ b/src/script/mod_storage.rs
@@ -616,6 +616,14 @@ mod tests {
 
     }
 
+    #[test]
+    fn txn_order() {
+        eval!("\"hello\" HLC CONCAT DUP [\"world\" ASSOC [ASSOC?] READ] WRITE 0x00 EQUAL?", env, result, {
+            assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x01"));
+            assert_eq!(env.pop(), None);
+        });
+    }
+
     use test::Bencher;
 
     #[bench]

--- a/src/script/queue.rs
+++ b/src/script/queue.rs
@@ -1,0 +1,81 @@
+#[derive(Debug)]
+pub struct Queue<T> {
+    max_size: usize,
+    count: usize,
+    elements: Vec<T>
+}
+
+#[derive(Debug, PartialEq)]
+pub enum InsertError {
+    Full
+}
+
+impl<T> Queue<T> {
+    pub fn new(max_size: usize) -> Self {
+        Queue {
+            max_size: max_size,
+            count: 0,
+            elements: Vec::new()
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.count
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.max_size
+    }
+
+    pub fn push(&mut self, el: T) -> Result<usize, InsertError> {
+        if self.count >= self.max_size {
+            return Err(InsertError::Full)
+        }
+        self.count += 1;
+        self.elements.push(el);
+        Ok(self.count)
+    }
+
+    pub fn peek(&self) -> Option<&T> {
+        self.elements.last()
+    }
+
+    pub fn pop(&mut self) -> Option<T> {
+        match self.elements.pop() {
+            Some(el) => {
+                self.count -= 1;
+                Some(el)
+            },
+            None => None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use script::queue::{Queue, InsertError};
+
+    #[test]
+    fn create_queue() {
+        let queue: Queue<String> = Queue::new(usize::max_value());
+        assert_eq!(queue.capacity(), usize::max_value());
+    }
+
+    #[test]
+    fn max_size() {
+        let mut queue: Queue<String> = Queue::new(1);
+        assert_eq!(queue.push("a".to_owned()).unwrap(), 1);
+        assert_eq!(queue.push("a".to_owned()).unwrap_err(), InsertError::Full);
+    }
+
+    #[test]
+    fn push_pop() {
+        let mut queue: Queue<String> = Queue::new(10);
+        assert_eq!(queue.len(), 0);
+        assert_eq!(queue.push("a".to_owned()).unwrap(), 1);
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue.pop().unwrap(), "a".to_owned());
+        assert_eq!(queue.len(), 0);
+    }
+
+}


### PR DESCRIPTION
Solution: Use a queue to make transaction picker straight forward and easier to reason about.

This uncovered some badly defined doc tests where tests that now require a transaction were not in one. That has been taken care of.

https://github.com/PumpkinDB/PumpkinDB/issues/160