### PR TITLE
Problem: default pumpkindb dir affects local repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 .idea
 .DS_Store
 *.rs.bk
+pumpkin.db*


### PR DESCRIPTION
By default, pumpkindb creates `pumpkin.db` directory
in the current working directory. This often leaves this directory
in a local repository, making it a nuisance when working with Git.

Solution: put pumpkin.db into .gitignore
