### PR TITLE
Problem: No way to specify a pumpkin config file

### DIFF
--- a/pumpkindb_engine/Cargo.toml
+++ b/pumpkindb_engine/Cargo.toml
@@ -31,7 +31,6 @@ rust-crypto = "^0.2"
 log = "0.3.6"
 log4rs = { version = "0.6.1", features = ["toml_format"] }
 serde_json = "0.9.8"
-clap = "2.20.5"
 num_cpus = "1.3.0"
 rand = "0.3.15"
 memmap = "0.5.2"

--- a/pumpkindb_server/Cargo.toml
+++ b/pumpkindb_server/Cargo.toml
@@ -16,6 +16,7 @@ doc = false
 name = "pumpkindb"
 
 [dependencies]
+clap = "2.22.1"
 nom = "^2.1"
 mio = "0.6.4"
 byteorder = "1.0.0"

--- a/pumpkindb_term/Cargo.toml
+++ b/pumpkindb_term/Cargo.toml
@@ -20,7 +20,7 @@ nom = "^2.1"
 rustyline = "1.0.0"
 ansi_term = "0.9.0"
 uuid = { version = "0.4.0", features = ["v4"] }
-clap = "2.20.5"
+clap = "2.22.1"
 byteorder = "1.0.0"
 
 pumpkinscript = { version = "0.2", path = "../pumpkinscript" }


### PR DESCRIPTION
Solution: Parse the arguments when starting up
the server, and allow the user to pass in a
configuration file.