### PR TITLE
Problem: Nom result type leaking from pumpkinscript

### DIFF
--- a/pumpkindb_engine/Cargo.toml
+++ b/pumpkindb_engine/Cargo.toml
@@ -12,7 +12,6 @@ authors = ["Guillaume Gauvrit <guillaume@gauvr.it>",
            "Yurii Rashkovskii <yrashk@gmail.com>"]
 
 [dependencies]
-nom = "^2.1"
 snowflake = { git = "https://github.com/yrashk/snowflake.git", branch="pub-fields" }
 lmdb-zero = "0.4.0"
 config = "0.3.1"

--- a/pumpkindb_engine/src/crates.rs
+++ b/pumpkindb_engine/src/crates.rs
@@ -12,9 +12,6 @@ extern crate matches;
 #[cfg(test)]
 extern crate test;
 
-// Parser
-extern crate nom;
-
 extern crate core;
 
 extern crate num_bigint;

--- a/pumpkindb_engine/src/script/mod.rs
+++ b/pumpkindb_engine/src/script/mod.rs
@@ -260,7 +260,7 @@ impl<'a> Env<'a> {
 }
 
 
-use nom;
+use pumpkinscript;
 
 #[inline]
 pub fn offset_by_size(size: usize) -> usize {
@@ -597,7 +597,7 @@ impl<'a> Scheduler<'a> {
         if program.len() == 0 {
             return Ok(());
         }
-        if let nom::IResult::Done(rest, data) = binparser::data(program) {
+        if let pumpkinscript::ParseResult::Done(rest, data) = binparser::data(program) {
             if env.aborting_try.is_empty() {
                 env.push(&data[offset_by_size(data.len())..]);
             }
@@ -605,7 +605,7 @@ impl<'a> Scheduler<'a> {
                 env.program.push(rest);
             }
             Ok(())
-        } else if let nom::IResult::Done(rest, instruction) =
+        } else if let pumpkinscript::ParseResult::Done(rest, instruction) =
             binparser::instruction_or_internal_instruction(program) {
             if rest.len() > 0 {
                 env.program.push(rest);

--- a/pumpkindb_engine/src/script/mod_core.rs
+++ b/pumpkindb_engine/src/script/mod_core.rs
@@ -14,7 +14,7 @@ use std::marker::PhantomData;
 
 use std::collections::BTreeMap;
 
-use nom;
+use pumpkinscript;
 use num_bigint::BigUint;
 use num_traits::{Zero, One};
 use core::ops::Sub;
@@ -55,7 +55,7 @@ lazy_static! {
       let ref defs : Vec<Vec<u8>> = *BUILTIN_DEFS;
       for definition in defs {
           match binparser::instruction(definition.as_slice()) {
-              nom::IResult::Done(&[0x81, b':', ref rest..], _) => {
+              pumpkinscript::ParseResult::Done(&[0x81, b':', ref rest..], _) => {
                   let instruction = &definition[0..definition.len() - rest.len() - 2];
                   map.insert(instruction, Vec::from(rest));
               },
@@ -346,7 +346,7 @@ impl<'a> Handler<'a> {
         let instruction = stack_pop!(env);
         let value = stack_pop!(env);
         match binparser::instruction(instruction) {
-            nom::IResult::Done(_, _) => {
+            pumpkinscript::ParseResult::Done(_, _) => {
                 let slice = alloc_slice!(value.len() + offset_by_size(value.len()), env);
                 write_size_into_slice!(value.len(), slice);
                 let offset = offset_by_size(value.len());
@@ -371,7 +371,7 @@ impl<'a> Handler<'a> {
         let instruction = stack_pop!(env);
         let value = stack_pop!(env);
         match binparser::instruction(instruction) {
-            nom::IResult::Done(_, _) => {
+            pumpkinscript::ParseResult::Done(_, _) => {
                 #[cfg(feature = "scoped_dictionary")]
                 {
                     let mut dict = env.dictionary.pop().unwrap();

--- a/pumpkindb_engine/src/script/mod_stack.rs
+++ b/pumpkindb_engine/src/script/mod_stack.rs
@@ -9,7 +9,7 @@ use super::{Env, EnvId, Module, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVA
 
 use std::marker::PhantomData;
 
-use nom;
+use pumpkinscript;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 
@@ -246,7 +246,7 @@ impl<'a> Handler<'a> {
         let mut current = stack_pop!(env);
         while current.len() > 0 {
             match binparser::data(current) {
-                nom::IResult::Done(rest, val) => {
+                pumpkinscript::ParseResult::Done(rest, val) => {
                     env.push(&val[offset_by_size(val.len())..]);
                     current = rest
                 }

--- a/pumpkindb_server/Cargo.toml
+++ b/pumpkindb_server/Cargo.toml
@@ -17,7 +17,6 @@ name = "pumpkindb"
 
 [dependencies]
 clap = "2.22.1"
-nom = "^2.1"
 mio = "0.6.4"
 byteorder = "1.0.0"
 memmap = "0.5.2"

--- a/pumpkindb_server/src/main.rs
+++ b/pumpkindb_server/src/main.rs
@@ -9,7 +9,6 @@
 extern crate mio;
 extern crate memmap;
 extern crate byteorder;
-extern crate nom;
 extern crate rand;
 extern crate num_cpus;
 #[macro_use]

--- a/pumpkindb_server/src/server.rs
+++ b/pumpkindb_server/src/server.rs
@@ -12,7 +12,6 @@ use std::sync::Mutex;
 use std::collections::BTreeMap;
 
 use slab;
-use nom;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use mio::channel as mio_chan;
@@ -83,7 +82,7 @@ impl Server {
                            original_topic == "unsubscriptions".as_bytes() {
                             let mut input = Vec::from(message);
                             let topic = match binparser::data(input.clone().as_slice()) {
-                                nom::IResult::Done(rest, data) => {
+                                pumpkinscript::ParseResult::Done(rest, data) => {
                                     let (_, size) = binparser::data_size(data).unwrap();
                                     input = Vec::from(rest);
                                     Vec::from(&data[pumpkinscript::offset_by_size(size)..])
@@ -92,7 +91,7 @@ impl Server {
                             };
                             let token = Token(match binparser::data(input.clone()
                                 .as_slice()) {
-                                nom::IResult::Done(_, data) => {
+                                pumpkinscript::ParseResult::Done(_, data) => {
                                     let (_, size) = binparser::data_size(data).unwrap();
                                     BigUint::from_bytes_be(&data[script::offset_by_size(size)..])
                                         .to_u64()

--- a/pumpkindb_term/Cargo.toml
+++ b/pumpkindb_term/Cargo.toml
@@ -16,7 +16,6 @@ name = "pumpkindb-term"
 
 [dependencies]
 config = "0.3.1"
-nom = "^2.1"
 rustyline = "1.0.0"
 ansi_term = "0.9.0"
 uuid = { version = "0.4.0", features = ["v4"] }

--- a/pumpkindb_term/src/main.rs
+++ b/pumpkindb_term/src/main.rs
@@ -6,7 +6,6 @@
 
 
 extern crate config;
-extern crate nom;
 extern crate rustyline;
 extern crate ansi_term;
 extern crate uuid;
@@ -140,7 +139,7 @@ fn main() {
                                     let mut s = String::new();
                                     while input.len() > 0 {
                                         match pumpkinscript::binparser::data(input.clone().as_slice()) {
-                                            nom::IResult::Done(rest, data) => {
+                                            pumpkinscript::ParseResult::Done(rest, data) => {
                                                 let (_, size) = pumpkinscript::binparser::data_size(data)
                                                     .unwrap();
                                                 let data = &data[script::offset_by_size(size)..];

--- a/pumpkinscript/src/lib.rs
+++ b/pumpkinscript/src/lib.rs
@@ -101,3 +101,5 @@ pub enum ParseError {
     /// Unparseable remainder
     Superfluous(Vec<u8>),
 }
+
+pub use nom::IResult as ParseResult;


### PR DESCRIPTION
Engine, server and term crates currently use a nom result type to check the
parser result from pumpkinscript.

Solution: re-export nom::IResult as pumpkinscript::ParseResult

Fixes #204

cc @theduke 