### PR TITLE
Problem: server hangs in some subscription/sending scenarios

### DIFF
--- a/pumpkindb_server/Cargo.toml
+++ b/pumpkindb_server/Cargo.toml
@@ -30,6 +30,7 @@ log4rs = { version = "0.6.1", features = ["toml_format"] }
 config = "0.3.1"
 lazy_static = "0.2.2"
 lmdb-zero = "0.4.0"
+uuid = { version = "0.4", features = ["v4"] }
 
 pumpkinscript = { version = "0.2", path = "../pumpkinscript" }
 pumpkindb_engine = { version = "0.2", path = "../pumpkindb_engine" }

--- a/pumpkindb_server/src/main.rs
+++ b/pumpkindb_server/src/main.rs
@@ -23,6 +23,7 @@ extern crate lazy_static;
 extern crate config;
 #[macro_use]
 extern crate clap;
+extern crate uuid;
 
 extern crate pumpkinscript;
 extern crate pumpkindb_engine;


### PR DESCRIPTION
```shell
$ ./target/debug/pumpkindb-term
Connected to PumpkinDB at 127.0.0.1:9981
To send an expression, end it with `.`
Type \h for help.
PumpkinDB> "a" SUBSCRIBE "b" "a" SEND.
thread 'main' panicked at 'Incomplete(Size(99))', pumpkindb_term/src/main.rs:178
note: Run with `RUST_BACKTRACE=1` for a backtrace.
$ ./target/debug/pumpkindb-term
Connected to PumpkinDB at 127.0.0.1:9981
To send an expression, end it with `.`
Type \h for help.
PumpkinDB> 1.
0x01
PumpkinDB> "a" SUBSCRIBE "b" "a" SEND.
thread 'main' panicked at 'Incomplete(Size(99))', pumpkindb_term/src/main.rs:178
note: Run with `RUST_BACKTRACE=1` for a backtrace.
$ ./target/debug/pumpkindb-term
Connected to PumpkinDB at 127.0.0.1:9981
To send an expression, end it with `.`
Type \h for help.
PumpkinDB> 1.
^C
```

Solution: map subscriptions not to tokens, but uuids, since tokens
are re-usable.

Make sure the subscription receiver is re-registered for polling again.

Also, hook unsubscriptions in so they actually work.

Fixes #210