### PR TITLE
Problem: ackermann benchmark is slow

### DIFF
--- a/pumpkindb_engine/src/script/mod.rs
+++ b/pumpkindb_engine/src/script/mod.rs
@@ -819,4 +819,14 @@ mod tests {
                     b);
     }
 
+    #[bench]
+    fn ackermann_stack(b: &mut Bencher) {
+        // HT @5HT
+        bench_eval!("[OVER 0 EQUAL? [1 UINT/ADD NIP] \
+        [DUP 0 EQUAL? [DROP 1 UINT/SUB 1 ack] [OVER 1 UINT/SUB -ROT 1 UINT/SUB ack ack] IFELSE] IFELSE] \
+        'ack DEF \
+        3 4 ack",
+                    b);
+    }
+
 }


### PR DESCRIPTION
It clocks at 28-30ms for `3 4 ack` on my laptop.

Solution: provide a pure stack-based implementation of `ack` to compare it with
the one that uses dictionaries (the original
one).

This improves benchmark performance by about 20%.

Both benchmarks were kept to track the difference in the approach.