### PR TITLE
Problem: contributors in toml files are hard to maintain

### DIFF
--- a/pumpkindb_engine/Cargo.toml
+++ b/pumpkindb_engine/Cargo.toml
@@ -7,11 +7,7 @@ homepage = "http://pumpkindb.org"
 keywords = [ "pumpkindb", "database" ]
 categories = [ "database" ]
 
-authors = ["Christoph Herzog <chris@theduke.at>",
-           "Guillaume Gauvrit <guillaume@gauvr.it>",
-           "Ómar Yasin <omarkj@gmail.com>",
-           "Stuart Hinson <stuart.hinson@gmail.com>",
-           "Yurii Rashkovskii <yrashk@gmail.com>"]
+authors = ["Yurii Rashkovskii <yrashk@gmail.com>"]
 
 [dependencies]
 snowflake = { git = "https://github.com/yrashk/snowflake.git", branch="pub-fields" }

--- a/pumpkindb_server/Cargo.toml
+++ b/pumpkindb_server/Cargo.toml
@@ -7,11 +7,7 @@ homepage = "http://pumpkindb.org"
 keywords = [ "pumpkindb", "database" ]
 categories = [ "database" ]
 
-authors = ["Christoph Herzog <chris@theduke.at>",
-           "Guillaume Gauvrit <guillaume@gauvr.it>",
-           "Ómar Yasin <omarkj@gmail.com>",
-           "Stuart Hinson <stuart.hinson@gmail.com>",
-           "Yurii Rashkovskii <yrashk@gmail.com>"]
+authors = ["Yurii Rashkovskii <yrashk@gmail.com>"]
 
 [[bin]]
 doc = false

--- a/pumpkindb_term/Cargo.toml
+++ b/pumpkindb_term/Cargo.toml
@@ -6,11 +6,7 @@ repository = "https://github.com/PumpkinDB/PumpkinDB"
 homepage = "http://pumpkindb.org"
 keywords = [ "pumpkindb", "database" ]
 
-authors = ["Christoph Herzog <chris@theduke.at>",
-           "Guillaume Gauvrit <guillaume@gauvr.it>",
-           "Ómar Yasin <omarkj@gmail.com>",
-           "Stuart Hinson <stuart.hinson@gmail.com>",
-           "Yurii Rashkovskii <yrashk@gmail.com>"]
+authors = ["Yurii Rashkovskii <yrashk@gmail.com>"]
 
 [[bin]]
 doc = false

--- a/pumpkinscript/Cargo.toml
+++ b/pumpkinscript/Cargo.toml
@@ -7,11 +7,7 @@ homepage = "http://pumpkindb.org"
 keywords = [ "pumpkindb", "pumpkinscript", "parsing" ]
 categories = [ "database", "parsing" ]
 
-authors = ["Christoph Herzog <chris@theduke.at>",
-           "Guillaume Gauvrit <guillaume@gauvr.it>",
-           "Ómar Yasin <omarkj@gmail.com>",
-           "Stuart Hinson <stuart.hinson@gmail.com>",
-           "Yurii Rashkovskii <yrashk@gmail.com>"]
+authors = ["Yurii Rashkovskii <yrashk@gmail.com>"]
 
 [dependencies]
 nom = "^2.1"


### PR DESCRIPTION
Every contributor is mentioned in a dedicated file anyway, so
maintaining a list of contributors in each toml file is rather
cumbersome and redundant.

Solution: don't mention contributors in Cargo.toml's.