### PR TITLE
Problem: builds are stuck on a randomly picked nightly release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - stable
-  - nightly-2017-03-14
+  - nightly
 matrix:
   allow_failures:
     - rust: stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   matrix:
     - channel: stable
       target: x86_64-pc-windows-msvc
-    - channel: nightly-2017-03-14
+    - channel: nightly
       target: x86_64-pc-windows-msvc
 
 matrix:


### PR DESCRIPTION
That release was picked because another newer release was broken.
This is no longer an issue.

Solution: revert to latest nightly Rust. The motivation for this
is to enable us to track breaking changes as soon as they happen
and address them one by one.