### PR TITLE
Problem: not all modules are necessary at all times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ test:
 	cargo test --all -- --nocapture
 	cargo test --all --features="experimental" -- --nocapture
 	cargo test --all --features="scoped_dictionary" -- --nocapture
-	cargo test --all --features="static_module_dispatch" -- --nocapture
 	./target/debug/pumpkindb-doctests
 
 doc:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,5 +26,4 @@ test_script:
   - cargo test --all -- --nocapture
   - cargo test --all --features="experimental" -- --nocapture
   - cargo test --all --features="scoped_dictionary" -- --nocapture
-  - cargo test --all --features="static_module_dispatch" -- --nocapture
   - target\debug\pumpkindb-doctests

--- a/doc/FEATURES.md
+++ b/doc/FEATURES.md
@@ -20,8 +20,6 @@ in`default`), the feature gate can be dropped.
 
 ## Current experimental features
 
-* `static_module_dispatch` (opt-in required, not in `experimental`, [issue #152](https://github.com/PumpkinDB/PumpkinDB/issues/152))
-
 ## Graduated features
 
 Graduated features are enabled by default, but in the source code,

--- a/pumpkindb_engine/Cargo.toml
+++ b/pumpkindb_engine/Cargo.toml
@@ -41,7 +41,30 @@ quickcheck_macros = "0.4.1"
 matches = "0.1.4"
 
 [features]
-default = ["scoped_dictionary"]
+default = ["scoped_dictionary", "standard_mods"]
+
 experimental = []
 scoped_dictionary = []
 static_module_dispatch = []
+
+# Modules
+
+standard_mods = [ "mod_binaries",
+                  "mod_core",
+                  "mod_hash",
+                  "mod_hlc",
+                  "mod_json",
+                  "mod_numbers",
+                  "mod_stack",
+                  "mod_storage",
+                  "mod_msg"]
+
+mod_binaries = []
+mod_core = []
+mod_hash = []
+mod_hlc = []
+mod_json = []
+mod_numbers = []
+mod_stack = []
+mod_storage = []
+mod_msg = []

--- a/pumpkindb_engine/Cargo.toml
+++ b/pumpkindb_engine/Cargo.toml
@@ -45,7 +45,6 @@ default = ["scoped_dictionary", "standard_mods"]
 
 experimental = []
 scoped_dictionary = []
-static_module_dispatch = []
 
 # Modules
 

--- a/pumpkindb_engine/src/lib.rs
+++ b/pumpkindb_engine/src/lib.rs
@@ -4,8 +4,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #![feature(slice_patterns, advanced_slice_patterns)]
-#![cfg_attr(test, feature(test))]
+#![feature(struct_field_attributes)]
 
+#![cfg_attr(test, feature(test))]
 #![cfg_attr(not(target_os = "windows"), feature(alloc, heap_api))]
 #![feature(alloc)]
 

--- a/pumpkindb_engine/src/script/dispatcher.rs
+++ b/pumpkindb_engine/src/script/dispatcher.rs
@@ -1,0 +1,171 @@
+// Copyright (c) 2017, All Contributors (see CONTRIBUTORS file)
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use super::*;
+
+pub trait Dispatcher<'a> {
+    #[allow(unused_variables)]
+    fn init(&mut self, env: &mut Env<'a>, pid: EnvId) {}
+    #[allow(unused_variables)]
+    fn done(&mut self, env: &mut Env<'a>, pid: EnvId) {}
+    fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a>;
+}
+
+include!("macros.rs");
+
+#[cfg(not(feature = "static_module_dispatch"))]
+macro_rules! for_each_dispatcher {
+    ($module: ident, $dispatcher : expr, $expr: expr) => {
+        for mut $module in $dispatcher.dispatchers.iter_mut() {
+            $expr
+        }
+    };
+}
+
+#[cfg(feature = "static_module_dispatch")]
+macro_rules! for_each_dispatcher {
+    ($module: ident, $dispatcher : expr, $expr: expr) => {{
+        #[cfg(feature="mod_core")]
+        {
+           let ref mut $module = $dispatcher.core;
+           $expr
+        }
+        #[cfg(feature="mod_stack")]
+        {
+           let ref mut $module = $dispatcher.stack;
+           $expr
+        }
+        #[cfg(feature="mod_binaries")]
+        {
+           let ref mut $module = $dispatcher.binaries;
+           $expr
+        }
+        #[cfg(feature="mod_numbers")]
+        {
+           let ref mut $module = $dispatcher.numbers;
+           $expr
+        }
+        #[cfg(feature="mod_storage")]
+        {
+           let ref mut $module = $dispatcher.storage;
+           $expr
+        }
+        #[cfg(feature="mod_hash")]
+        {
+           let ref mut $module = $dispatcher.hash;
+           $expr
+        }
+        #[cfg(feature="mod_hlc")]
+        {
+           let ref mut $module = $dispatcher.hlc;
+           $expr
+        }
+        #[cfg(feature="mod_json")]
+        {
+           let ref mut $module = $dispatcher.json;
+           $expr
+        }
+        #[cfg(feature="mod_msg")]
+        {
+           let ref mut $module = $dispatcher.msg;
+           $expr
+        }
+
+    }};
+}
+
+pub struct StandardDispatcher<'a> {
+    #[cfg(not(feature = "static_module_dispatch"))]
+    dispatchers: Vec<Box<Dispatcher<'a> + 'a>>,
+    #[cfg(all(feature = "static_module_dispatch", feature = "mod_core"))]
+    core: mod_core::Handler<'a>,
+    #[cfg(all(feature = "static_module_dispatch", feature = "mod_stack"))]
+    stack: mod_stack::Handler<'a>,
+    #[cfg(all(feature = "static_module_dispatch", feature = "mod_binaries"))]
+    binaries: mod_binaries::Handler<'a>,
+    #[cfg(all(feature = "static_module_dispatch", feature = "mod_numbers"))]
+    numbers: mod_numbers::Handler<'a>,
+    #[cfg(all(feature = "static_module_dispatch", feature = "mod_storage"))]
+    storage: mod_storage::Handler<'a>,
+    #[cfg(all(feature = "static_module_dispatch", feature = "mod_hash"))]
+    hash: mod_hash::Handler<'a>,
+    #[cfg(all(feature = "static_module_dispatch", feature = "mod_hlc"))]
+    hlc: mod_hlc::Handler<'a>,
+    #[cfg(all(feature = "static_module_dispatch", feature = "mod_json"))]
+    json: mod_json::Handler<'a>,
+    #[cfg(all(feature = "static_module_dispatch", feature = "mod_msg"))]
+    msg: mod_msg::Handler<'a>,
+}
+
+impl<'a> StandardDispatcher<'a> {
+
+    pub fn new<P: 'a, S: 'a>(db: &'a storage::Storage<'a>,
+               publisher: P, subscriber: S,
+               timestamp_state: Arc<timestamp::Timestamp>)
+               -> Self where P : messaging::Publisher, S : messaging::Subscriber {
+        #[cfg(not(feature="static_module_dispatch"))]
+        {
+            let mut mods : Vec<Box<Dispatcher<'a> + 'a>> = Vec::new();
+            #[cfg(feature="mod_core")]
+            mods.push(Box::new(mod_core::Handler::new()));
+            #[cfg(feature="mod_stack")]
+            mods.push(Box::new(mod_stack::Handler::new()));
+            #[cfg(feature="mod_binaries")]
+            mods.push(Box::new(mod_binaries::Handler::new()));
+            #[cfg(feature="mod_numbers")]
+            mods.push(Box::new(mod_numbers::Handler::new()));
+            #[cfg(feature="mod_storage")]
+            mods.push(Box::new(mod_storage::Handler::new(db)));
+            #[cfg(feature="mod_hash")]
+            mods.push(Box::new(mod_hash::Handler::new()));
+            #[cfg(feature="mod_hlc")]
+            mods.push(Box::new(mod_hlc::Handler::new(timestamp_state)));
+            #[cfg(feature="mod_json")]
+            mods.push(Box::new(mod_json::Handler::new()));
+            #[cfg(feature="mod_msg")]
+            mods.push(Box::new(mod_msg::Handler::new(publisher, subscriber)));
+            return StandardDispatcher {
+                dispatchers: mods,
+            }
+        }
+        #[cfg(feature = "static_module_dispatch")]
+        {
+                return StandardDispatcher {
+                #[cfg(feature = "mod_core")]
+                    core: mod_core::Handler::new(),
+                #[cfg(feature = "mod_stack")]
+                    stack: mod_stack::Handler::new(),
+                #[cfg(feature = "mod_binaries")]
+                    binaries: mod_binaries::Handler::new(),
+                #[cfg(feature = "mod_numbers")]
+                    numbers: mod_numbers::Handler::new(),
+                #[cfg(feature = "mod_storage")]
+                    storage: mod_storage::Handler::new(db),
+                #[cfg(feature = "mod_hash")]
+                    hash: mod_hash::Handler::new(),
+                #[cfg(feature = "mod_hlc")]
+                    hlc: mod_hlc::Handler::new(timestamp_state),
+                #[cfg(feature = "mod_json")]
+                    json: mod_json::Handler::new(),
+                #[cfg(feature = "mod_msg")]
+                    msg: mod_msg::Handler::new(publisher, subscriber),
+            }
+        }
+    }
+}
+
+impl<'a> Dispatcher<'a> for StandardDispatcher<'a> {
+    fn init(&mut self, env: &mut Env<'a>, pid: EnvId) {
+        for_each_dispatcher!(disp, self, disp.init(env, pid));
+    }
+    fn done(&mut self, env: &mut Env<'a>, pid: EnvId) {
+        for_each_dispatcher!(disp, self, disp.done(env, pid));
+    }
+    fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
+        for_each_dispatcher!(disp, self, try_instruction!(env, disp.handle(env, instruction, pid)));
+        Err(Error::UnknownInstruction)
+    }
+}

--- a/pumpkindb_engine/src/script/macros.rs
+++ b/pumpkindb_engine/src/script/macros.rs
@@ -214,7 +214,8 @@ macro_rules! eval {
                 let publisher_clone = messaging_accessor.clone();
                 let subscriber_clone = messaging_accessor.clone();
                 let timestamp_clone = timestamp.clone();
-                let (sender, receiver) = Scheduler::<dispatcher::StandardDispatcher>::create_sender();
+                let (sender, receiver) = Scheduler::<dispatcher::StandardDispatcher<
+                    messaging::SimpleAccessor, messaging::SimpleAccessor>>::create_sender();
                 let handle = scope.spawn(move || {
                     let mut scheduler = Scheduler::new(
                         dispatcher::StandardDispatcher::new(&db,
@@ -287,7 +288,8 @@ macro_rules! bench_eval {
                 let publisher_clone = messaging_accessor.clone();
                 let subscriber_clone = messaging_accessor.clone();
                 let timestamp_clone = timestamp.clone();
-                let (sender, receiver) = Scheduler::<dispatcher::StandardDispatcher>::create_sender();
+                let (sender, receiver) = Scheduler::<dispatcher::StandardDispatcher<
+                    messaging::SimpleAccessor, messaging::SimpleAccessor>>::create_sender();
                 let handle = scope.spawn(move || {
                     let mut scheduler = Scheduler::new(
                         dispatcher::StandardDispatcher::new(&db,

--- a/pumpkindb_engine/src/script/macros.rs
+++ b/pumpkindb_engine/src/script/macros.rs
@@ -214,13 +214,12 @@ macro_rules! eval {
                 let publisher_clone = messaging_accessor.clone();
                 let subscriber_clone = messaging_accessor.clone();
                 let timestamp_clone = timestamp.clone();
-                let (sender, receiver) = Scheduler::create_sender();
+                let (sender, receiver) = Scheduler::<dispatcher::StandardDispatcher>::create_sender();
                 let handle = scope.spawn(move || {
                     let mut scheduler = Scheduler::new(
-                        &db,
-                        publisher_clone.clone(),
-                        subscriber_clone.clone(),
-                        timestamp_clone,
+                        dispatcher::StandardDispatcher::new(&db,
+                          publisher_clone.clone(), subscriber_clone.clone(),
+                          timestamp_clone),
                         receiver);
                     scheduler.run()
                 });
@@ -288,13 +287,11 @@ macro_rules! bench_eval {
                 let publisher_clone = messaging_accessor.clone();
                 let subscriber_clone = messaging_accessor.clone();
                 let timestamp_clone = timestamp.clone();
-                let (sender, receiver) = Scheduler::create_sender();
+                let (sender, receiver) = Scheduler::<dispatcher::StandardDispatcher>::create_sender();
                 let handle = scope.spawn(move || {
                     let mut scheduler = Scheduler::new(
-                        &db,
-                        publisher_clone,
-                        subscriber_clone,
-                        timestamp_clone,
+                        dispatcher::StandardDispatcher::new(&db,
+                           publisher_clone, subscriber_clone, timestamp_clone),
                         receiver,
                     );
                     scheduler.run()

--- a/pumpkindb_engine/src/script/mod_binaries.rs
+++ b/pumpkindb_engine/src/script/mod_binaries.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use super::{Env, EnvId, Module, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
+use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
             offset_by_size, STACK_TRUE, STACK_FALSE};
 
 use std::marker::PhantomData;
@@ -25,7 +25,7 @@ pub struct Handler<'a> {
     phantom: PhantomData<&'a ()>,
 }
 
-impl<'a> Module<'a> for Handler<'a> {
+impl<'a> Dispatcher<'a> for Handler<'a> {
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
         try_instruction!(env, self.handle_ltp(env, instruction, pid));
         try_instruction!(env, self.handle_gtp(env, instruction, pid));

--- a/pumpkindb_engine/src/script/mod_core.rs
+++ b/pumpkindb_engine/src/script/mod_core.rs
@@ -6,7 +6,7 @@
 
 use pumpkinscript::{parse_bin, binparser, textparser};
 
-use super::{Env, EnvId, Module, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
+use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
             offset_by_size, STACK_TRUE, STACK_FALSE};
 
 use std::marker::PhantomData;
@@ -65,7 +65,7 @@ pub struct Handler<'a> {
     phantom: PhantomData<&'a ()>,
 }
 
-impl<'a> Module<'a> for Handler<'a> {
+impl<'a> Dispatcher<'a> for Handler<'a> {
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
         try_instruction!(env, self.handle_builtins(env, instruction, pid));
         try_instruction!(env, self.handle_dowhile(env, instruction, pid));
@@ -388,7 +388,7 @@ mod tests {
 
     use pumpkinscript::parse;
     use messaging;
-    use script::{Scheduler, RequestMessage, ResponseMessage, EnvId};
+    use script::{Scheduler, RequestMessage, ResponseMessage, EnvId, dispatcher};
     use std::sync::mpsc;
     use std::sync::Arc;
     use std::fs;

--- a/pumpkindb_engine/src/script/mod_hash.rs
+++ b/pumpkindb_engine/src/script/mod_hash.rs
@@ -25,7 +25,7 @@ instruction!(HASH_SHA512_256, b"\x8FHASH/SHA512-256");
 // `Sha512Trunc256`, which is the 64-bit `Sha512` algorithm with the result truncated to 256 bits.
 //
 
-use super::{Env, EnvId, Module, PassResult, Error, ERROR_EMPTY_STACK, offset_by_size};
+use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, offset_by_size};
 use crypto::digest::Digest;
 use crypto::sha1::Sha1;
 use crypto::sha2::*;
@@ -52,7 +52,7 @@ macro_rules! hash_instruction {
     };
 }
 
-impl<'a> Module<'a> for Handler<'a> {
+impl<'a> Dispatcher<'a> for Handler<'a> {
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
         try_instruction!(env, self.handle_hash_sha1(env, instruction, pid));
         try_instruction!(env, self.handle_hash_sha224(env, instruction, pid));

--- a/pumpkindb_engine/src/script/mod_hlc.rs
+++ b/pumpkindb_engine/src/script/mod_hlc.rs
@@ -14,7 +14,7 @@ instruction!(HLC, b"\x83HLC");
 instruction!(HLC_LC, b"\x86HLC/LC");
 instruction!(HLC_TICK, b"\x88HLC/TICK");
 
-use super::{Env, EnvId, Module, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
+use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
             offset_by_size};
 use timestamp;
 
@@ -28,7 +28,7 @@ pub struct Handler<'a> {
     timestamp: Arc<timestamp::Timestamp>,
 }
 
-impl<'a> Module<'a> for Handler<'a> {
+impl<'a> Dispatcher<'a> for Handler<'a> {
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
         try_instruction!(env, self.handle_hlc(env, instruction, pid));
         try_instruction!(env, self.handle_hlc_lc(env, instruction, pid));

--- a/pumpkindb_engine/src/script/mod_json.rs
+++ b/pumpkindb_engine/src/script/mod_json.rs
@@ -24,7 +24,7 @@ instruction!(JSON_HASQ, b"\x89JSON/HAS?");
 instruction!(JSON_STRING_TO, b"\x8dJSON/STRING->");
 instruction!(JSON_TO_STRING, b"\x8dJSON/->STRING");
 
-use super::{Env, EnvId, Module, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
+use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
             offset_by_size, STACK_TRUE, STACK_FALSE};
 use serde_json as json;
 
@@ -59,7 +59,7 @@ macro_rules! json_is_a {
     }};
 }
 
-impl<'a> Module<'a> for Handler<'a> {
+impl<'a> Dispatcher<'a> for Handler<'a> {
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
         try_instruction!(env, self.handle_jsonq(env, instruction, pid));
         try_instruction!(env, self.handle_json_objectq(env, instruction, pid));

--- a/pumpkindb_engine/src/script/mod_msg.rs
+++ b/pumpkindb_engine/src/script/mod_msg.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use super::{Env, EnvId, Module, PassResult, Error, ERROR_EMPTY_STACK, offset_by_size};
+use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, offset_by_size};
 use super::super::messaging;
 
 use std::marker::PhantomData;
@@ -19,7 +19,7 @@ pub struct Handler<'a, P: messaging::Publisher, S: messaging::Subscriber> {
     phantom: PhantomData<&'a ()>,
 }
 
-impl<'a, P: messaging::Publisher, S: messaging::Subscriber> Module<'a> for Handler<'a, P, S> {
+impl<'a, P: messaging::Publisher, S: messaging::Subscriber> Dispatcher<'a> for Handler<'a, P, S> {
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
         try_instruction!(env, self.handle_publish(env, instruction, pid));
         try_instruction!(env, self.handle_subscribe(env, instruction, pid));
@@ -97,7 +97,7 @@ mod tests {
 
     use pumpkinscript::parse;
     use messaging;
-    use script::{Env, Scheduler, Error, RequestMessage, ResponseMessage, EnvId};
+    use script::{Env, Scheduler, Error, RequestMessage, ResponseMessage, EnvId, dispatcher};
     use std::sync::mpsc;
     use std::sync::Arc;
     use std::fs;

--- a/pumpkindb_engine/src/script/mod_numbers.rs
+++ b/pumpkindb_engine/src/script/mod_numbers.rs
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use super::{Env, EnvId, Module, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
+use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
             offset_by_size, STACK_TRUE, STACK_FALSE};
 
 use std::marker::PhantomData;
@@ -102,7 +102,7 @@ pub struct Handler<'a> {
     phantom: PhantomData<&'a ()>,
 }
 
-impl<'a> Module<'a> for Handler<'a> {
+impl<'a> Dispatcher<'a> for Handler<'a> {
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
         try_instruction!(env, self.handle_uint_add(env, instruction, pid));
         try_instruction!(env, self.handle_uint_sub(env, instruction, pid));

--- a/pumpkindb_engine/src/script/mod_stack.rs
+++ b/pumpkindb_engine/src/script/mod_stack.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use pumpkinscript::{offset_by_size, binparser};
-use super::{Env, EnvId, Module, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE};
+use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE};
 
 use std::marker::PhantomData;
 
@@ -29,7 +29,7 @@ pub struct Handler<'a> {
     phantom: PhantomData<&'a ()>,
 }
 
-impl<'a> Module<'a> for Handler<'a> {
+impl<'a> Dispatcher<'a> for Handler<'a> {
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
         try_instruction!(env, self.handle_drop(env, instruction, pid));
         try_instruction!(env, self.handle_dup(env, instruction, pid));

--- a/pumpkindb_engine/src/script/mod_storage.rs
+++ b/pumpkindb_engine/src/script/mod_storage.rs
@@ -17,7 +17,7 @@ use storage::GlobalWriteLock;
 use std::mem;
 use std::error::Error as StdError;
 use std::collections::HashMap;
-use super::{Env, EnvId, Module, PassResult, Error, STACK_TRUE, STACK_FALSE, offset_by_size,
+use super::{Env, EnvId, Dispatcher, PassResult, Error, STACK_TRUE, STACK_FALSE, offset_by_size,
             ERROR_EMPTY_STACK, ERROR_INVALID_VALUE, ERROR_DUPLICATE_KEY, ERROR_NO_TX,
             ERROR_UNKNOWN_KEY, ERROR_DATABASE};
 use byteorder::{BigEndian, WriteBytesExt};
@@ -191,7 +191,7 @@ macro_rules! cursorq_op {
     }};
 }
 
-impl<'a> Module<'a> for Handler<'a> {
+impl<'a> Dispatcher<'a> for Handler<'a> {
     fn done(&mut self, _: &mut Env, pid: EnvId) {
         self.txns.get_mut(&pid)
             .and_then(|queue| {
@@ -584,7 +584,7 @@ fn copy_to_stack(env: &mut Env, (key, val): (&[u8], &[u8])) -> Result<(), Error>
 mod tests {
     use pumpkinscript::{parse, offset_by_size};
     use messaging;
-    use script::{Env, Scheduler, Error, RequestMessage, ResponseMessage, EnvId};
+    use script::{Env, Scheduler, Error, RequestMessage, ResponseMessage, EnvId, dispatcher};
 
     use byteorder::WriteBytesExt;
     use std::sync::mpsc;

--- a/pumpkindb_server/src/main.rs
+++ b/pumpkindb_server/src/main.rs
@@ -44,6 +44,7 @@ use clap::{App, Arg};
 
 use pumpkindb_engine::{script, storage, timestamp};
 use pumpkindb_engine::script::dispatcher;
+use pumpkindb_engine::messaging;
 
 lazy_static! {
  static ref ENVIRONMENT: lmdb::Environment = {
@@ -163,7 +164,8 @@ fn main() {
 
     for i in 0..num_cpus::get() {
         info!("Starting scheduler on core {}.", i);
-        let (sender, receiver) = script::Scheduler::<dispatcher::StandardDispatcher>::create_sender();
+        let (sender, receiver) = script::Scheduler::<dispatcher::StandardDispatcher<
+            messaging::SimpleAccessor, messaging::SimpleAccessor>>::create_sender();
         let storage_clone = storage.clone();
         let timestamp_clone = timestamp.clone();
 

--- a/tests/doctests/src/main.rs
+++ b/tests/doctests/src/main.rs
@@ -51,7 +51,8 @@ fn eval(name: &[u8], script: &[u8], timestamp: Arc<timestamp::Timestamp>) {
         let publisher_clone = simple_accessor.clone();
         let subscriber_clone = simple_accessor.clone();
         let timestamp_clone = timestamp.clone();
-        let (sender, receiver) = Scheduler::<dispatcher::StandardDispatcher>::create_sender();
+        let (sender, receiver) = Scheduler::<dispatcher::StandardDispatcher<
+            messaging::SimpleAccessor, messaging::SimpleAccessor>>::create_sender();
         let handle = scope.spawn(move || {
             let mut scheduler = Scheduler::new(
                 dispatcher::StandardDispatcher::new(&db, publisher_clone, subscriber_clone,


### PR DESCRIPTION
For certain embedding scenarios, not all modules that PumpkinDB engine considers "standard" are in fact  necessary. Also, in other scenarios, additional modules are required.

Solution: introduce Dispatch trait that can handle different configurations of statically and dynamically added modules.