### PR TITLE
Problem: logging every scheduler is a bit verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,11 @@ After that, you can run PumpkinDB server this way:
 ```shell
 $ cargo build --all
 $ ./target/debug/pumpkindb
-2017-03-18T09:55:24.510400-07:00 WARN pumpkindb - No logging configuration specified, switching to console logging
-2017-03-18T09:55:24.511821-07:00 INFO pumpkindb - Starting up
-2017-03-18T09:55:24.512955-07:00 INFO pumpkindb::storage - Available disk space is approx. 26Gb, setting database map size to it
-2017-03-18T09:55:24.514145-07:00 INFO pumpkindb - Starting scheduler on core 0.
-# ...
-2017-03-18T09:55:24.515344-07:00 INFO pumpkindb - Starting scheduler on core 7.
-2017-03-18T09:55:24.515468-07:00 INFO pumpkindb::server - Listening on 0.0.0.0:9981
+2017-04-03T10:43:49.667667-07:00 WARN pumpkindb - No logging configuration specified, switching to console logging
+2017-04-03T10:43:49.668660-07:00 INFO pumpkindb - Starting up
+2017-04-03T10:43:49.674139-07:00 INFO pumpkindb_engine::storage - Available disk space is approx. 7Gb, setting database map size to it
+2017-04-03T10:43:49.675759-07:00 INFO pumpkindb - Starting 8 schedulers
+2017-04-03T10:43:49.676113-07:00 INFO pumpkindb - Listening on 0.0.0.0:9981
 ```
 
 You can connect to it using `pumpkindb-term`:

--- a/pumpkindb_server/src/main.rs
+++ b/pumpkindb_server/src/main.rs
@@ -162,8 +162,10 @@ fn main() {
     let storage = Arc::new(storage::Storage::new(&ENVIRONMENT));
     let timestamp = Arc::new(timestamp::Timestamp::new(Some(hlc_state)));
 
-    for i in 0..num_cpus::get() {
-        info!("Starting scheduler on core {}.", i);
+    let cpus = num_cpus::get();
+    info!("Starting {} schedulers", cpus);
+    for i in 0..cpus {
+        debug!("Starting scheduler on core {}.", i);
         let (sender, receiver) = script::Scheduler::<dispatcher::StandardDispatcher<
             messaging::SimpleAccessor, messaging::SimpleAccessor>>::create_sender();
         let storage_clone = storage.clone();


### PR DESCRIPTION
The information density communicated by each of the following
lines is low:

```
2017-04-03T10:41:48.788230-07:00 INFO pumpkindb - Starting scheduler on core 0.
2017-04-03T10:41:48.788356-07:00 INFO pumpkindb - Starting scheduler on core 1.
2017-04-03T10:41:48.788454-07:00 INFO pumpkindb - Starting scheduler on core 2.
2017-04-03T10:41:48.788537-07:00 INFO pumpkindb - Starting scheduler on core 3.
2017-04-03T10:41:48.788646-07:00 INFO pumpkindb - Starting scheduler on core 4.
2017-04-03T10:41:48.788752-07:00 INFO pumpkindb - Starting scheduler on core 5.
2017-04-03T10:41:48.788847-07:00 INFO pumpkindb - Starting scheduler on core 6.
2017-04-03T10:41:48.788941-07:00 INFO pumpkindb - Starting scheduler on core 7.
```

Solution: log the total number of schedulers and log every scheduler's
start as a debug log message (so it will not be seen under normal circumstances).