### PR TITLE
Problem: ?CURSOR/SEEKLAST doesn't unwrap cursor correctly

### DIFF
--- a/pumpkindb_engine/src/script/builtins
+++ b/pumpkindb_engine/src/script/builtins
@@ -20,7 +20,7 @@ STARTSWITH? : 2DUP LENGTH SWAP LENGTH SWAP UINT/LT? [2DROP 0] [DUP LENGTH 0 SWAP
                    key [] 511 key LENGTH UINT/SUB 0xff PAD CONCAT 'padded SET
                    c padded CURSOR/SEEK?
                    [`c ?CURSOR/CUR UNWRAP DROP `key STARTSWITH?
-                                      [`c ?CURSOR/CUR] [c ?CURSOR/PREV] IFELSE] 'positioning SET
+                                      [``c ?CURSOR/CUR] [``c ?CURSOR/PREV] IFELSE] 'positioning SET
                    positioning [`c CURSOR/LAST? DROP `positioning EVAL] IFELSE
                   ] EVAL/SCOPED.
 CURSOR/DOWHILE : ['iterator SET 'closure SET 'c SET


### PR DESCRIPTION
In some parts, it'll wrap cursor by reference (as a name) instead of its value.

Solution: ensure proper cursor unwrapping.