### PR TITLE
Problem: HLC clock can't observe another timestamp

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -117,6 +117,7 @@
  * Sequencing
    * [HLC](script/HLC.md)
    * [HLC/LC](script/HLC/LC.md)
+   * [HLC/OBSERVE](script/HLC/OBSERVE.md)
    * [HLC/TICK](script/HLC/TICK.md)
  * Miscellaneous
    * [FEATURE?](script/FEATUREQ.md)

--- a/doc/script/HLC/OBSERVE.md
+++ b/doc/script/HLC/OBSERVE.md
@@ -1,0 +1,38 @@
+# HLC/OBSERVE
+
+{% method -%}
+
+Updates HLC timestamp from provided value
+
+Input stack: `a`
+
+Output stack: `b`
+
+Removes topmost item off the stack (an HLC timestamp) and updates Hybrid Logical
+Clock based on its value.
+
+{% common -%}
+
+```
+PumpkinDB> HLC HLC/OBSERVE.
+0x0000000034b07f85d24f7dc800000000
+```
+
+{% endmethod %}
+
+## Allocation
+
+Allocates for the new timestamp to be pushed on stack.
+
+## Errors
+
+[EmptyStack](../errors/EmptyStack.md) error if there are fewer than one item on the stack
+[InvalidValue](./errors/InvalidValue.md) error if the given value is not a valid HLC.
+
+## Tests
+
+```test
+observe_tick : HLC DUP HLC/TICK HLC/OBSERVE LT?.
+invalid_value : [1 HLC/OBSERVE] TRY UNWRAP 0x03 EQUAL?.
+empty_stack : [HLC/OBSERVE] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/pumpkindb_engine/Cargo.toml
+++ b/pumpkindb_engine/Cargo.toml
@@ -17,7 +17,7 @@ lazy_static = "0.2.2"
 num-bigint = "0.1.35"
 num-traits = "0.1.36"
 libc = "0.2.20"
-hybrid-clocks = "0.3.2"
+hybrid-clocks = "0.3.3"
 byteorder = "1.0.0"
 uuid = { version = "0.4.0", features = ["v4"] }
 glob = "0.2.11"

--- a/pumpkindb_engine/src/script/mod_hlc.rs
+++ b/pumpkindb_engine/src/script/mod_hlc.rs
@@ -13,6 +13,7 @@
 instruction!(HLC, b"\x83HLC");
 instruction!(HLC_LC, b"\x86HLC/LC");
 instruction!(HLC_TICK, b"\x88HLC/TICK");
+instruction!(HLC_OBSERVE, b"\x8BHLC/OBSERVE");
 
 use super::{Env, EnvId, Module, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
             offset_by_size};
@@ -33,6 +34,8 @@ impl<'a> Module<'a> for Handler<'a> {
         try_instruction!(env, self.handle_hlc(env, instruction, pid));
         try_instruction!(env, self.handle_hlc_lc(env, instruction, pid));
         try_instruction!(env, self.handle_hlc_tick(env, instruction, pid));
+        try_instruction!(env, self.handle_hlc_observe(env, instruction, pid));
+
         Err(Error::UnknownInstruction)
     }
 }
@@ -121,6 +124,36 @@ impl<'a> Handler<'a> {
             env.push(slice);
 
             Ok(())
+        } else {
+            Err(Error::UnknownInstruction)
+        }
+    }
+
+    #[inline]
+    pub fn handle_hlc_observe(&mut self,
+                              env: &mut Env<'a>,
+                              instruction: &'a [u8],
+                              _: EnvId)
+                              -> PassResult<'a> {
+        if instruction == HLC_OBSERVE {
+            if let Some(mut observed_bytes) = env.pop() {
+                if let Ok(observed_time) = hlc::Timestamp::read_bytes(&mut observed_bytes) {
+                    if self.timestamp.observe(&observed_time).is_err() {
+                        return Err(error_invalid_value!(observed_bytes));
+                    }
+
+                    let slice = alloc_slice!(16, env);
+                    let _ = self.timestamp.hlc().write_bytes(&mut slice[0..]).unwrap();
+
+                    env.push(slice);
+
+                    Ok(())
+                } else {
+                    Err(error_invalid_value!(observed_bytes))
+                }
+            } else {
+                Err(error_empty_stack!())
+            }
         } else {
             Err(Error::UnknownInstruction)
         }


### PR DESCRIPTION
Solution: Implement HLC/OBSERVE instruction

Addresses #199 

*NOTE* This commit uses a fork of the hybrid-clocks repo. Changes to it are necessary for tests to pass.