### PR TITLE
Problem: debugging scripts is hard

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -119,6 +119,8 @@
    * [HLC/LC](script/HLC/LC.md)
    * [HLC/OBSERVE](script/HLC/OBSERVE.md)
    * [HLC/TICK](script/HLC/TICK.md)
+ * Debugging
+   * [TRACE](script/TRACE.md)
  * Miscellaneous
    * [FEATURE?](script/FEATUREQ.md)
    * [$SYSTEM/VERSION](script/_SYSTEM/VERSION.md)

--- a/doc/script/TRACE.md
+++ b/doc/script/TRACE.md
@@ -1,0 +1,34 @@
+# TRACE
+
+**Only available in pumpkindb-term**
+
+{% method -%}
+
+Takes the topmost item and sends it back to the terminal as a traced value.
+
+Input stack: `value`
+Output stack: none
+
+This instruction is used for debugging purposes. Multiple invocations are possible per script.
+
+{% common -%}
+
+```
+PumpkinDB> "start" TRACE 1.
+Trace: "start"
+0x01
+```
+
+{% endmethod %}
+
+## Allocation
+
+None
+
+## Errors
+
+[EmptyStack](./errors/EmptyStack.md) error if there is less than one item on the stack
+
+## Tests
+
+No tests, this instruction is only defined in pumpkindb-term

--- a/pumpkindb_term/src/main.rs
+++ b/pumpkindb_term/src/main.rs
@@ -94,9 +94,10 @@ fn main() {
                 let mut program = String::new();
                 let text_str = text.as_str();
                 let text_bytes = text_str.as_bytes();
-                if text_bytes.len() >= 2 && text_bytes[0] == 92u8 {
-                    if text_bytes[1] == 104u8 {
+                if text_bytes.len() >= 2 && text_bytes[0] == b'\\' {
+                    if text_bytes[1] == b'h' {
                         println!("\nTo send an expression, end it with `.`");
+                        println!("To trace a value in the script use TRACE instruction");
                         println!("To quit, hit ^D");
                         println!("Further help online at http://pumpkindb.org/doc/");
                         println!("Missing a feature? Let us know at \

--- a/pumpkindb_term/src/main.rs
+++ b/pumpkindb_term/src/main.rs
@@ -28,7 +28,7 @@ use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use rustyline::history::History;
 
-use ansi_term::Colour::Red;
+use ansi_term::Colour::{Red, Cyan};
 
 use uuid::Uuid;
 
@@ -37,6 +37,22 @@ use clap::{Arg, App};
 use pumpkindb_engine::script;
 use pumpkinscript::compose::*;
 use pumpkinscript::compose::Item::*;
+
+fn print_item(s: &mut String, data: &[u8]) {
+    if data.iter()
+        .all(|c| *c >= 0x20 && *c <= 0x7e) {
+        let _ = write!(s,
+                       "{:?} ",
+                       str::from_utf8(data)
+                           .unwrap());
+    } else {
+        let _ = write!(s, "0x");
+        for b in Vec::from(data) {
+            let _ = write!(s, "{:02x}", b);
+        }
+        let _ = write!(s, " ");
+    }
+}
 
 fn main() {
 
@@ -104,85 +120,114 @@ fn main() {
                     match pumpkinscript::parse(&program) {
                         Ok(compiled) => {
                             let uuid = Uuid::new_v4();
-                            let msg: Vec<u8> = Program(vec![Data(&compiled),
-                                                            Instruction("TRY"),
+                            let trace: Vec<u8> = Program(vec![
+                                Data(&[1]), Instruction("WRAP"),
+                                Data("TRACE".as_bytes()),
+                                Instruction("SWAP"),
+                                Instruction("CONCAT"),
+                                Data(uuid.as_bytes()),
+                                Instruction("PUBLISH"),
+                               ]).into();
+                            let msg: Vec<u8> = Program(vec![
                                                             Data(uuid.as_bytes()),
-                                                            InstructionRef("topic"),
-                                                            Instruction("SET"),
-                                                            Instruction("STACK"),
-                                                            Instruction("topic"),
                                                             Instruction("SUBSCRIBE"),
+                                                            InstructionRef("___subscription___"),
+                                                            Instruction("SET"),
+                                                            Data(&trace),
+                                                            InstructionRef("TRACE"),
+                                                            Instruction("DEF"),
+                                                            Data(&compiled),
+                                                            Instruction("TRY"),
+                                                            Instruction("STACK"),
+                                                            Data("RESULT".as_bytes()),
                                                             Instruction("SWAP"),
-                                                            Instruction("topic"),
+                                                            Instruction("CONCAT"),
+                                                            Data(uuid.as_bytes()),
                                                             Instruction("PUBLISH"),
-                                                            Instruction("UNSUBSCRIBE")])
-                                .into();
+                                                            Instruction("___subscription___"),
+                                                            Instruction("UNSUBSCRIBE")
+                               ]).into();
                             let mut buf = [0u8; 4];
 
                             BigEndian::write_u32(&mut buf, msg.len() as u32);
                             stream.write_all(buf.as_ref()).unwrap();
                             stream.write_all(msg.as_ref()).unwrap();
 
-                            stream.read(&mut buf).unwrap();
+                            let mut done = false;
 
-                            let msg_len = BigEndian::read_u32(&mut buf);
+                            while !done {
+                                stream.read(&mut buf).unwrap();
+                                let msg_len = BigEndian::read_u32(&mut buf);
 
-                            let s_ref = <TcpStream as Read>::by_ref(&mut stream);
+                                let s_ref = <TcpStream as Read>::by_ref(&mut stream);
 
-                            r.clear();
+                                r.clear();
 
-                            match s_ref.take(msg_len as u64).read_to_end(&mut r) {
-                                Ok(0) => {}
-                                Ok(_) => {
-                                    let mut input = r.clone();
-                                    let mut top_level = true;
-                                    let mut s = String::new();
-                                    while input.len() > 0 {
-                                        match pumpkinscript::binparser::data(input.clone().as_slice()) {
-                                            pumpkinscript::ParseResult::Done(rest, data) => {
-                                                let (_, size) = pumpkinscript::binparser::data_size(data)
-                                                    .unwrap();
-                                                let data = &data[script::offset_by_size(size)..];
+                                match s_ref.take(msg_len as u64).read_to_end(&mut r) {
+                                    Ok(0) => {}
+                                    Ok(_) => {
+                                        if r[0..5].to_vec() == b"TRACE" {
+                                            let input = r[5..msg_len as usize].to_vec();
+                                            let mut s = String::new();
+                                            if cfg!(target_os = "windows") {
+                                                let _ = write!(&mut s, "Trace: ");
+                                            } else {
+                                                let _ = write!(&mut s,
+                                                               "{}", Cyan.paint("Trace: "));
+                                            }
+                                            match pumpkinscript::binparser::data(&input.clone()) {
+                                                pumpkinscript::ParseResult::Done(_, data) => {
+                                                    let (_, size) = pumpkinscript::binparser::data_size(data)
+                                                        .unwrap();
+                                                    let data = &data[script::offset_by_size(size)..];
+                                                    print_item(&mut s, data);
+                                                },
+                                                e => {
+                                                    panic!("{:?}", e);
+                                                }
+                                            }
+                                            println!("{}", s);
+                                        } else if r[0..6].to_vec() == b"RESULT" {
+                                            let mut input = r[6..msg_len as usize].to_vec();
+                                            done = true;
+                                            let mut top_level = true;
+                                            let mut s = String::new();
+                                            while input.len() > 0 {
+                                                match pumpkinscript::binparser::data(&input.clone()) {
+                                                    pumpkinscript::ParseResult::Done(rest, data) => {
+                                                        let (_, size) = pumpkinscript::binparser::data_size(data)
+                                                            .unwrap();
+                                                        let data = &data[script::offset_by_size(size)..];
 
-                                                input = Vec::from(rest);
+                                                        input = Vec::from(rest);
 
-                                                if rest.len() == 0 && top_level {
-                                                    top_level = false;
-                                                    if data.len() > 0 {
-                                                        if cfg!(target_os = "windows") {
-                                                            let _ = write!(&mut s, "Error: ");
+                                                        if rest.len() == 0 && top_level {
+                                                            top_level = false;
+                                                            if data.len() > 0 {
+                                                                if cfg!(target_os = "windows") {
+                                                                    let _ = write!(&mut s, "Error: ");
+                                                                } else {
+                                                                    let _ = write!(&mut s,
+                                                                                   "{}",
+                                                                                   Red.paint("Error: "));
+                                                                }
+                                                                input = Vec::from(data);
+                                                            }
                                                         } else {
-                                                            let _ = write!(&mut s,
-                                                                           "{}",
-                                                                           Red.paint("Error: "));
+                                                            print_item(&mut s, data);
                                                         }
-                                                        input = Vec::from(data);
                                                     }
-                                                } else {
-                                                    if data.iter()
-                                                        .all(|c| *c >= 0x20 && *c <= 0x7e) {
-                                                        let _ = write!(&mut s,
-                                                                       "{:?} ",
-                                                                       str::from_utf8(data)
-                                                                           .unwrap());
-                                                    } else {
-                                                        let _ = write!(&mut s, "0x");
-                                                        for b in Vec::from(data) {
-                                                            let _ = write!(&mut s, "{:02x}", b);
-                                                        }
-                                                        let _ = write!(&mut s, " ");
+                                                    e => {
+                                                        panic!("{:?}", e);
                                                     }
                                                 }
                                             }
-                                            e => {
-                                                panic!("{:?}", e);
-                                            }
+                                            println!("{}", s);
                                         }
                                     }
-                                    println!("{}", s);
-                                }
-                                Err(e) => {
-                                    panic!("{}", e);
+                                    Err(e) => {
+                                        panic!("{}", e);
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
There is no easy way to look into what script is doing to be
able to debug it.

Solution: add experimental TRACE instruction to pumpkindb-term
(not available outside of it) that allows users to trace any values.

```
PumpkinDB> "test" TRACE 1.
Trace: "test"
0x01
```