### PR TITLE
Problem: nested WRITEs don't work as expected

### DIFF
--- a/doc/script/WRITE.md
+++ b/doc/script/WRITE.md
@@ -43,4 +43,6 @@ marker instruction.
 evals : [1] WRITE.
 invalid_code : [1 WRITE] TRY UNWRAP 0x05 EQUAL?.
 empty_stack : [WRITE] TRY UNWRAP 0x04 EQUAL?.
+nested_writes_shouldnt_work_for_now : [[[] WRITE] TRY] WRITE UNWRAP 0x09 EQUAL?.
+read_nested_writes_shouldnt_work_for_now : [[[] WRITE] TRY] READ UNWRAP 0x09 EQUAL?.
 ```

--- a/pumpkindb_engine/src/script/mod_storage.rs
+++ b/pumpkindb_engine/src/script/mod_storage.rs
@@ -238,6 +238,12 @@ impl<'a> Handler<'a> {
         match instruction {
             WRITE => {
                 let v = stack_pop!(env);
+                if self.txns.get(&pid).is_some() && self.txns.get(&pid).unwrap().len() > 0 {
+                    return Err(error_program!(
+                               "Nested WRITEs are not currently allowed".as_bytes(),
+                               "".as_bytes(),
+                               ERROR_DATABASE));
+                }
                 match self.db.write() {
                     None => Err(Error::Reschedule),
                     Some(result) =>


### PR DESCRIPTION
Naturally, one would expect a nested write to open a child
transaction within the scope of the existing transaction.
However, this doesn't currently happen (until we start supporting
lmdb's child transactions)

Solution: raise a database error with an appropriate description
on nested WRITEs