### PR TITLE
Problem: Scoped dictionaries clone parents instead of deferring

### DIFF
--- a/pumpkindb_engine/src/script/env.rs
+++ b/pumpkindb_engine/src/script/env.rs
@@ -135,10 +135,7 @@ impl<'a> Env<'a> {
 
     #[cfg(feature = "scoped_dictionary")]
     pub fn push_dictionary(&mut self) {
-        let dict = self.dictionary.pop().unwrap();
-        let new_dict = dict.clone();
-        self.dictionary.push(dict);
-        self.dictionary.push(new_dict);
+        self.dictionary.push(BTreeMap::new());
     }
 
     #[cfg(feature = "scoped_dictionary")]

--- a/pumpkindb_engine/src/script/mod.rs
+++ b/pumpkindb_engine/src/script/mod.rs
@@ -417,14 +417,21 @@ impl<'a, T: Dispatcher<'a>> Scheduler<'a, T> {
                          instruction: &'a [u8],
                          _: EnvId)
                          -> PassResult<'a> {
-        let len = env.dictionary.len();
-        let ref dict = env.dictionary[len - 1];
-        match dict.get(instruction) {
-            Some(def) => {
+        let mut found = false;
+
+        for i in (0..env.dictionary.len()).rev() {
+            let ref dict = env.dictionary[i];
+            if let Some(def) = dict.get(instruction) {
                 env.program.push(def);
-                Ok(())
-            },
-            None => Err(Error::UnknownInstruction)
+                found = true;
+                break;
+            }
+        }
+
+        if found {
+            Ok(())
+        } else {
+            Err(Error::UnknownInstruction)
         }
     }
 


### PR DESCRIPTION
Solution: Only store the differences between in child scoped dictionaries. If a key is not found in child, look for it in parent.