### PR TITLE
Problem: new users have a barrier to try latest PumpkinDB out

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+# Copyright (c) 2017, All Contributors (see CONTRIBUTORS file)
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Parts of this file are based on docker-rustup by Hannes de Jager
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 Hannes de Jager
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+FROM ubuntu:16.04
+
+RUN apt-get update \
+    && apt-get install -y curl file sudo build-essential
+
+RUN curl https://sh.rustup.rs > sh.rustup.rs \
+    && sh sh.rustup.rs -y \
+    && . $HOME/.cargo/env \
+    && echo 'source $HOME/.cargo/env' >> $HOME/.bashrc \
+    && rustup update \
+    && rustup target add x86_64-unknown-linux-musl
+
+RUN . $HOME/.cargo/env && mkdir /pumpkindb && cd /pumpkindb && rustup override set nightly
+
+COPY Makefile /pumpkindb/
+COPY Cargo.* /pumpkindb/
+COPY pumpkindb_engine /pumpkindb/pumpkindb_engine
+COPY pumpkindb_server /pumpkindb/pumpkindb_server
+COPY pumpkindb_term /pumpkindb/pumpkindb_term
+COPY pumpkinscript /pumpkindb/pumpkinscript
+COPY tests /pumpkindb/tests
+COPY doc /pumpkindb/doc
+
+RUN . $HOME/.cargo/env && cd /pumpkindb && cargo build --all --release
+RUN    mv /pumpkindb/target/release/pumpkindb /usr/local/bin \
+    && mv /pumpkindb/target/release/pumpkindb-term /usr/local/bin
+
+RUN echo "[storage]\npath=\"/db\"" > /pumpkindb/pumpkindb.toml
+
+EXPOSE 9981
+
+VOLUME /db
+WORKDIR /pumpkindb
+
+CMD pumpkindb -c /pumpkindb/pumpkindb.toml

--- a/README.md
+++ b/README.md
@@ -62,6 +62,33 @@ To name a few:
 
 You can download PumpkinDB releases [from GitHub](https://github.com/PumpkinDB/PumpkinDB/releases).
 
+### Docker
+
+You can try out latest PumpkinDB HEAD revision by building a docker image:
+
+```shell
+$ docker build . -t pumpkindb
+```
+
+And then running a server:
+ 
+```shell
+$ docker run -p 9981:9981 -ti pumpkindb
+2017-04-12T02:52:47.440873517+00:00 WARN pumpkindb - No logging configuration specified, switching to console logging
+2017-04-12T02:52:47.440983318+00:00 INFO pumpkindb - Starting up
+2017-04-12T02:52:47.441122740+00:00 INFO pumpkindb_engine::storage - Available disk space is approx. 56Gb, setting database map size to it
+2017-04-12T02:52:47.441460231+00:00 INFO pumpkindb - Starting 4 schedulers
+2017-04-12T02:52:47.442375937+00:00 INFO pumpkindb - Listening on 0.0.0.0:9981
+```
+
+And finally, connecting to it using `pumpkindb-term`:
+
+```
+$ docker run -ti pumpkindb pumpkindb-term 172.17.0.1:9981 # replace IP with the docker host IP
+```
+
+### Building from the source code
+
 You are also welcome to clone the repository and build
 it yourself. You will need Rust Nightly to do this. The easiest way to get it is to use
 [rustup](https://www.rust-lang.org/en-US/install.html)


### PR DESCRIPTION
They are required to prepare Rust development environment,
which is definitely a bit of a barrier.

Solution: provide a Dockerfile to build a docker image.

Note that in this version, for a yet unknown reason, when
`docker run -ti pumpkindb pumpkindb-term 172.17.0.1:9981`
is invoked, it messes up the terminal a little bit but
works fine after that. This is something we need to fix.