### PR TITLE
Problem: stuck on an arbitrarily chosen nightly Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - stable
-  - nightly-2017-04-11
+  - nightly
 matrix:
   allow_failures:
     - rust: stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   matrix:
     - channel: stable
       target: x86_64-pc-windows-msvc
-    - channel: nightly-2017-04-11
+    - channel: nightly
       target: x86_64-pc-windows-msvc
 
 matrix:


### PR DESCRIPTION
At that time, we had to do this because current nightly
was broken. It isn't anymore.

Solution: Revert "Problem: nightly + rustup is broken at the moment"

This reverts commit fac009d911aac942848cd06eb930b392f0bed5e7.