### PR TITLE
Problem: unused `test` feature in pumpkindb_server

### DIFF
--- a/pumpkindb_server/src/main.rs
+++ b/pumpkindb_server/src/main.rs
@@ -4,7 +4,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #![feature(slice_patterns, advanced_slice_patterns)]
-#![cfg_attr(test, feature(test))]
 
 extern crate mio;
 extern crate memmap;


### PR DESCRIPTION
```
 --> pumpkindb_server/src/main.rs:7:27
  |
7 | #![cfg_attr(test, feature(test))]
  |                           ^^^^
  |
  = note: #[warn(unused_features)] on by default
```

Solution: drop the feature