### PR TITLE
Problem: GT? and LT? doctests test signed integers

### DIFF
--- a/doc/script/GTQ.md
+++ b/doc/script/GTQ.md
@@ -37,19 +37,4 @@ greater : 0x20 0x10 GT?.
 equal : 0x10 0x10 GT? NOT.
 requires_two_items_0 : [GT?] TRY UNWRAP 0x04 EQUAL?.
 requires_two_items_1 : [1 GT?] TRY UNWRAP 0x04 EQUAL?.
-
-more_different_sign_usized : +1 -1 GT?.
-more_same_sign_unsized : -1 -2 GT?.
-
-more_different_sign_i8 : +1i8 -1i8 GT?.
-more_same_sign_i8 : -1i8 -2i8 GT?.
-
-more_different_sign_i16 : +1i16 -1i16 GT?.
-more_same_sign_i16 : -1i16 -2i16 GT?.
-
-more_different_sign_i32 : +1i32 -1i32 GT?.
-more_same_sign_i32 : -1i32 -2i32 GT?.
-
-more_different_sign_i64 : +1i64 -1i64 GT?.
-more_same_sign_i64 : -1i64 -2i64 GT?.
 ```

--- a/doc/script/INT/README.md
+++ b/doc/script/INT/README.md
@@ -1,11 +1,16 @@
 # INT
 
-By convention, INTs are signed big integers. They are serialized as a sign
-prefix (`0` for negative, `1` for positive and zero) followed by a variable
-sized bigint serialization.
+By convention, INTs are signed big integers. They are serialized as a byte-long
+sign prefix (`0` for negative, `1` for positive and zero) followed by a variable
+sized bigint serialization. They are lexicographically sorted.
 
 ```test
 zero : -0 +0 EQUAL?.
 neg_zero : -1 +0 LT?.
 neg_pos : -1 +1 LT?.
+more_different_sign_usized : +1 -1 GT?.
+more_same_sign_unsized : -1 -2 GT?.
+more_different_sign_usized : -1 +1 LT?.
+more_same_sign_unsized : -2 -1 LT?.
 ```
+

--- a/doc/script/INT_SIZED/README.md
+++ b/doc/script/INT_SIZED/README.md
@@ -1,6 +1,7 @@
 # INT[size]
 
-INTs are signed sized intergers, the size can be i8, i16, i32 or i64.
+INTs are signed sized integers, the size can be i8, i16, i32 or i64.
+
 
 ```test
 no_sign_i8 : 1i8 +1i8 EQUAL?.
@@ -11,4 +12,28 @@ zero_i8  : -0i8 +0i8 EQUAL?.
 zero_i16 : -0i16 +0i16 EQUAL?.
 zero_i32 : -0i32 +0i32 EQUAL?.
 zero_i64 : -0i64 +0i64 EQUAL?.
+
+more_different_sign_i8 : +1i8 -1i8 GT?.
+more_same_sign_i8 : -1i8 -2i8 GT?.
+
+more_different_sign_i16 : +1i16 -1i16 GT?.
+more_same_sign_i16 : -1i16 -2i16 GT?.
+
+more_different_sign_i32 : +1i32 -1i32 GT?.
+more_same_sign_i32 : -1i32 -2i32 GT?.
+
+more_different_sign_i64 : +1i64 -1i64 GT?.
+more_same_sign_i64 : -1i64 -2i64 GT?.
+
+less_different_sign_i8 : -1i8 1i8 LT?.
+less_same_sign_i8 : -2i8 -1i8 LT?.
+
+less_different_sign_i16 : -1i16 1i16 LT?.
+less_same_sign_i16 : -2i16 -1i16 LT?.
+
+less_different_sign_i32 : -1i32 1i32 LT?.
+less_same_sign_i32 : -2i32 -1i32 LT?.
+
+less_different_sign_i64 : -1i64 1i64 LT?.
+less_same_sign_i64 : -2i64 -1i64 LT?.
 ```

--- a/doc/script/LTQ.md
+++ b/doc/script/LTQ.md
@@ -37,19 +37,4 @@ greater : 0x20 0x10 LT? NOT.
 equal : 0x10 0x10 LT? NOT.
 requires_two_items_0 : [LT?] TRY UNWRAP 0x04 EQUAL?.
 requires_two_items_1 : [1 LT?] TRY UNWRAP 0x04 EQUAL?.
-
-more_different_sign_usized : -1 +1 LT?.
-more_same_sign_unsized : -2 -1 LT?.
-
-less_different_sign_i8 : -1i8 1i8 LT?.
-less_same_sign_i8 : -2i8 -1i8 LT?.
-
-less_different_sign_i16 : -1i16 1i16 LT?.
-less_same_sign_i16 : -2i16 -1i16 LT?.
-
-less_different_sign_i32 : -1i32 1i32 LT?.
-less_same_sign_i32 : -2i32 -1i32 LT?.
-
-less_different_sign_i64 : -1i64 1i64 LT?.
-less_same_sign_i64 : -2i64 -1i64 LT?.
 ```


### PR DESCRIPTION
While there's nothing inherently wrong with this,
these tests cross the boundaries between generic
binaries and signed integers convention.

Solution: move these doctests to their respective sections