### PR TITLE
Problem: INT convention representation is a bit wasteful

### DIFF
--- a/doc/script/INT/EQUALQ.md
+++ b/doc/script/INT/EQUALQ.md
@@ -32,10 +32,9 @@ Runtime allocation for supporting primitives
 ## Tests
 
 ```test
-invalid : [0xff 0xff INT/EQUAL?] TRY UNWRAP 0x03 EQUAL?.
 not_equal : -1 +0 INT/EQUAL? NOT.
 equal : +1000 +1000 INT/EQUAL?.
-equal_diff_size : 0x010001 0x0101 INT/EQUAL?.
+equal_diff_size : 0x8000000001 0x81 INT/EQUAL?.
 requires_two_items_0 : [INT/EQUAL?] TRY UNWRAP 0x04 EQUAL?.
 requires_two_items_1 : [1 INT/EQUAL?] TRY UNWRAP 0x04 EQUAL?.
 ```

--- a/doc/script/INT/GTQ.md
+++ b/doc/script/INT/GTQ.md
@@ -34,10 +34,9 @@ Runtime allocation for supporting primitives
 ## Tests
 
 ```test
-invalid : [0xff 0xff INT/GT?] TRY UNWRAP 0x03 EQUAL?.
 less : +1 +2 INT/GT? NOT.
 greater : +2 +1 INT/GT?.
-greater_diff_size : 0x010002 0x0101 INT/GT?.
+greater_diff_size : 0x800002 0x81 INT/GT?.
 equal : +1 +1 INT/GT? NOT.
 requires_two_items_0 : [INT/GT?] TRY UNWRAP 0x04 EQUAL?.
 requires_two_items_1 : [1 INT/GT?] TRY UNWRAP 0x04 EQUAL?.

--- a/doc/script/INT/LTQ.md
+++ b/doc/script/INT/LTQ.md
@@ -34,9 +34,8 @@ Runtime allocation for supporting primitives
 ## Tests
 
 ```test
-invalid : [0xff 0xff INT/LT?] TRY UNWRAP 0x03 EQUAL?.
 less : +1 +2 INT/LT?.
-less_diff_size : 0x010001 0x0110 INT/LT?.
+less_diff_size : 0x800001 0x82 INT/LT?.
 greater : +2 +1 INT/LT? NOT.
 equal : +1 +1 INT/LT? NOT.
 requires_two_items_0 : [INT/LT?] TRY UNWRAP 0x04 EQUAL?.

--- a/pumpkindb_engine/src/script/mod_numbers.rs
+++ b/pumpkindb_engine/src/script/mod_numbers.rs
@@ -55,19 +55,19 @@ instruction!(INT_LTQ, (a, b => c), b"\x87INT/LT?");
 
 
 pub fn bytes_to_bigint(bytes: &[u8]) -> Option<BigInt> {
-    match bytes[0] {
-            0x00 => Some(Sign::Minus),
-            0x01 => Some(Sign::Plus),
+    match bytes[0] & 1 << 7 {
+            0b00000000 => Some(Sign::Minus),
+            0b10000000 => Some(Sign::Plus),
             _ => None
         }
         .and_then(|sign| Some(
                 {
-                    let mut bytes: Vec<u8> = Vec::from(&bytes[1..]);
-                    if sign == Sign::Plus { 
+                    let mut bytes: Vec<u8> = Vec::from(bytes);
+                    bytes[0] ^= 1u8 << 7;
+                    if sign == Sign::Plus {
                         BigInt::from_bytes_be(sign, bytes.as_slice())
                     } else {
                         for i in 0..bytes.len() {
-                            //flip.push(!byte);
                             bytes[i] = !bytes[i];
                         }
                         let mut nextbit = true;
@@ -96,6 +96,32 @@ macro_rules! bytes_to_bigint {
          None => return Err(error_invalid_value!($bytes))
        }
    };
+}
+
+macro_rules! bigint_to_bytes {
+    ($bigint: expr, $c_bytes: expr) => {
+        if $bigint.is_negative() {
+            for i in 0..$c_bytes.len() {
+                    $c_bytes[i] = !$c_bytes[i];
+                }
+                let mut nextbit = true;
+                for i in (0..$c_bytes.len()).rev() {
+                    $c_bytes[i] =  match $c_bytes[i].checked_add(1) {
+                        Some(v) => {
+                            nextbit = false;
+                            v
+                        },
+                        None => 0,
+                    };
+                    if !nextbit {
+                        break;
+                    }
+                }
+            $c_bytes[0] ^= 1u8 << 7;
+        } else {
+            $c_bytes[0] |= 1u8 << 7;
+        }
+    }
 }
 
 macro_rules! uint_comparison {
@@ -179,7 +205,6 @@ macro_rules! no_endianness_sized_int_op {
     ($env: expr, $read_op: ident, $op: ident, $write_op: ident) => {{
         let a = stack_pop!($env);
         let b = stack_pop!($env);
-       
         let mut a = Vec::from(a);
         a[0] ^= 1u8 << 7;
 
@@ -206,7 +231,6 @@ macro_rules! no_endianness_sized_int_op {
             Ok(_) => {},
             Err(_) => return Err(error_invalid_value!(a)),
         }
-        
         c_bytes[0] ^= 1u8 << 7;
 
         let slice = alloc_and_write!(c_bytes.as_slice(), $env);
@@ -373,34 +397,9 @@ impl<'a> Handler<'a> {
         }
 
         let c_int = a_int.unwrap().add(b_int.unwrap());
-
-        let mut bytes = if c_int.is_negative() {
-            vec![0x00]
-        } else {
-            vec![0x01]
-        };
         let (_, mut c_bytes) = c_int.to_bytes_be();
-        if c_int.is_negative() {
-            for i in 0..c_bytes.len() {
-                    c_bytes[i] = !c_bytes[i];
-                }
-                let mut nextbit = true;
-                for i in (0..c_bytes.len()).rev() {
-                    c_bytes[i] =  match c_bytes[i].checked_add(1) {
-                        Some(v) => {
-                            nextbit = false;
-                            v
-                        },
-                        None => 0,
-                    };
-                    if !nextbit {
-                        break;
-                    }
-                }
-        }
-
-        bytes.extend_from_slice(&c_bytes);
-        let slice = alloc_and_write!(bytes.as_slice(), env);
+        bigint_to_bytes!(c_int, c_bytes);
+        let slice = alloc_and_write!(c_bytes.as_slice(), env);
         env.push(slice);
         Ok(())
     }
@@ -426,34 +425,10 @@ impl<'a> Handler<'a> {
 
         let c_int = b_int.unwrap().sub(a_int.unwrap());
 
-        let mut bytes = if c_int.is_negative() {
-            vec![0x00]
-        } else {
-            vec![0x01]
-        };
         let (_, mut c_bytes) = c_int.to_bytes_be();
-        if c_int.is_negative() {
-            for i in 0..c_bytes.len() {
-                    c_bytes[i] = !c_bytes[i];
-                }
-                let mut nextbit = true;
-                for i in (0..c_bytes.len()).rev() {
-                    c_bytes[i] =  match c_bytes[i].checked_add(1) {
-                        Some(v) => {
-                            nextbit = false;
-                            v
-                        },
-                        None => 0,
-                    };
-                    if !nextbit {
-                        break;
-                    }
-                }
-        }
-
-        bytes.extend_from_slice(&c_bytes);
-        let slice = alloc_and_write!(bytes.as_slice(), env);
-        env.push(slice);
+        bigint_to_bytes!(c_int, c_bytes);
+        let slice = alloc_and_write!(c_bytes.as_slice(), env);
+        env.push(slice);        env.push(slice);
         Ok(())
     }
 
@@ -490,10 +465,9 @@ impl<'a> Handler<'a> {
         let a = stack_pop!(env);
         let a_uint = BigUint::from_bytes_be(a);
 
-        let mut bytes = vec![0x01];
-        let a_bytes = a_uint.to_bytes_be();
-        bytes.extend_from_slice(&a_bytes);
-        let slice = alloc_and_write!(bytes.as_slice(), env);
+        let mut a_bytes = a_uint.to_bytes_be();
+        a_bytes[0] |= 1u8 << 7;
+        let slice = alloc_and_write!(a_bytes.as_slice(), env);
 
         env.push(slice);
         Ok(())

--- a/pumpkinscript/src/textparser.rs
+++ b/pumpkinscript/src/textparser.rs
@@ -314,11 +314,6 @@ named!(sint<Vec<u8>>,
         sign: sign        >>
         biguint: biguint  >>
         ({
-            let mut bytes = if sign == Sign::Minus && !biguint.is_zero() {
-                vec![0x00]
-           } else {
-                vec![0x01]
-            };
            let big = biguint.to_bytes_be();
            let mut compv: Vec<u8> = vec![];
            //Encode with two's complement.
@@ -339,12 +334,12 @@ named!(sint<Vec<u8>>,
                         break;
                     }
                 }
-           } else {
+               compv[0] ^= 1u8 << 7;
+            } else {
                compv = big;
+               compv[0] |= 1u8 << 7;
            }
-           //compv[0] ^= 1u8 << 7;
-           bytes.extend_from_slice(&compv);
-           (sized_vec(bytes))
+           (sized_vec(compv))
         })));
 
 named!(uint<Vec<u8>>,
@@ -762,9 +757,8 @@ mod tests {
     #[test]
     fn test_signed_ints() {
         assert_eq!(parse("+0").unwrap(), parse("-0").unwrap());
-        assert_eq!(parse("+0").unwrap(), vec![2, 1, 0]);
-        assert_eq!(parse("+1").unwrap(), vec![2, 1, 1]);
-        assert_eq!(parse("-1").unwrap(), vec![2, 0, 255]);
+        assert_eq!(parse("+0").unwrap(), vec![1, 128]);
+        assert_eq!(parse("+1").unwrap(), vec![1, 129]);
+        assert_eq!(parse("-1").unwrap(), vec![1, 127]);
     }
-
 }


### PR DESCRIPTION
Solution: Use the most significant bit for the sign.