### PR TITLE
Problem: snowflake's ProcessUniqueId is not serializable to a binary

### DIFF
--- a/pumpkindb_engine/Cargo.toml
+++ b/pumpkindb_engine/Cargo.toml
@@ -10,7 +10,7 @@ categories = [ "database" ]
 authors = ["Yurii Rashkovskii <yrashk@gmail.com>"]
 
 [dependencies]
-snowflake = { git = "https://github.com/yrashk/snowflake.git", branch="pub-fields" }
+snowflake = { version = "1.3", features = ["serde_support"] }
 lmdb-zero = "0.4.0"
 config = "0.3.1"
 lazy_static = "0.2.2"
@@ -29,6 +29,7 @@ rust-crypto = "^0.2"
 log = "0.3.6"
 log4rs = { version = "0.6.1", features = ["toml_format"] }
 serde_json = "0.9.8"
+serde_cbor = "0.6.0"
 num_cpus = "1.3.0"
 rand = "0.3.15"
 memmap = "0.5.2"

--- a/pumpkindb_engine/src/crates.rs
+++ b/pumpkindb_engine/src/crates.rs
@@ -38,6 +38,7 @@ extern crate lazy_static;
 extern crate crypto;
 
 extern crate serde_json;
+extern crate serde_cbor;
 
 extern crate rand;
 


### PR DESCRIPTION
This makes it harder to use it for process-scoped unique values (cursor IDs,
subscription IDs, etc.) and it is often being replaced with UUIDs for that,
which are too global and much slower.

Solution: upgrade to snowflake 1.3 as it supports Serde serialization
and use serde_cbor to perform actual serializations