### PR TITLE
Problem: fixed-sized float +0.0/-0.0 encoding is inconsistent with signed integer's

### DIFF
--- a/pumpkinscript/src/textparser.rs
+++ b/pumpkinscript/src/textparser.rs
@@ -384,7 +384,13 @@ named!(float32<Vec<u8>>,
                    bytes.extend_from_slice(left);
                    bytes.extend_from_slice(b".");
                    bytes.extend_from_slice(right);
-                   let val = str::from_utf8(&bytes).unwrap().parse::<f32>().unwrap();
+                   let mut val = str::from_utf8(&bytes).unwrap().parse::<f32>().unwrap();
+                   // a little tricky: +0.0f32 == -0.0f32, but they don't serialize
+                   // to the same bytes. negative sign in the comparison left to indicate
+                   // intent, but technically unnecessary  
+                   if val == -0.0f32 {
+                       val = 0.0f32;
+                   }
                    (sized_vec(val.pack()))
                })));
 
@@ -406,7 +412,11 @@ named!(float64<Vec<u8>>,
                    bytes.extend_from_slice(left);
                    bytes.extend_from_slice(b".");
                    bytes.extend_from_slice(right);
-                   let val = str::from_utf8(&bytes).unwrap().parse::<f64>().unwrap();
+                   let mut val = str::from_utf8(&bytes).unwrap().parse::<f64>().unwrap();
+                   // see note on float32
+                   if val == -0.0f64 {
+                       val = 0.0f64;
+                   }
                    (sized_vec(val.pack()))
                })));
 


### PR DESCRIPTION
Solution: On parse, convert `-0.0f{32/64}` to pos

Root of the issue is that `+0.0f` and `-0.0f` don't serialize to the same value in `byteorder` crate (probably the correct behavior from its standpoint), so we flip the sign on parsing

Addresses #284 