### PR TITLE
Problem: a number of doctests are being ignored

### DIFF
--- a/doc/script/UINT_SIZED/SUB.md
+++ b/doc/script/UINT_SIZED/SUB.md
@@ -34,22 +34,22 @@ for the result.
 ## Tests
 
 ```test
-works_u8 : 2u8 1u8 UINT8/SUB 1 EQUAL?.
+works_u8 : 2u8 1u8 UINT8/SUB 1u8 EQUAL?.
 invalid_value_u8 : [1u8 2u8 UINT8/SUB] TRY UNWRAP 0x03 EQUAL?.
 empty_stack_u8 : [UINT8/SUB] TRY UNWRAP 0x04 EQUAL?.
 empty_stack_u8_1 : [1u8 UINT8/SUB] TRY UNWRAP 0x04 EQUAL?.
 
-works_u16 : 2u16 1u16 UINT16/SUB 1 EQUAL?.
+works_u16 : 2u16 1u16 UINT16/SUB 1u16 EQUAL?.
 invalid_value_u16 : [1u16 2u16 UINT16/SUB] TRY UNWRAP 0x03 EQUAL?.
 empty_stack_u16 : [UINT16/SUB] TRY UNWRAP 0x04 EQUAL?.
 empty_stack_u16_1 : [1u16 UINT16/SUB] TRY UNWRAP 0x04 EQUAL?.
 
-works_u32 : 2u32 1u32 UINT32/SUB 1 EQUAL?.
+works_u32 : 2u32 1u32 UINT32/SUB 1u32 EQUAL?.
 invalid_value_u32 : [1u32 2u32 UINT32/SUB] TRY UNWRAP 0x03 EQUAL?.
 empty_stack_u32 : [UINT32/SUB] TRY UNWRAP 0x04 EQUAL?.
 empty_stack_u32_1 : [1u32 UINT32/SUB] TRY UNWRAP 0x04 EQUAL?.
 
-works_u64 : 2u64 1u64 UINT64/SUB 1 EQUAL?.
+works_u64 : 2u64 1u64 UINT64/SUB 1u64 EQUAL?.
 invalid_value_u64 : [1u64 2u64 UINT64/SUB] TRY UNWRAP 0x03 EQUAL?.
 empty_stack_u64 : [UINT64/SUB] TRY UNWRAP 0x04 EQUAL?.
 empty_stack_u64_1 : [1u64 UINT64/SUB] TRY UNWRAP 0x04 EQUAL?.

--- a/pumpkindb_engine/src/script/mod_numbers.rs
+++ b/pumpkindb_engine/src/script/mod_numbers.rs
@@ -152,8 +152,8 @@ macro_rules! int_comparison {
 
 macro_rules! no_endianness_sized_uint_op {
     ($env: expr, $read_op: ident, $op: ident, $write_op: ident) => {{
-        let mut a = stack_pop!($env);
         let mut b = stack_pop!($env);
+        let mut a = stack_pop!($env);
 
         let a_int = match a.$read_op() {
             Ok(v) => v,
@@ -184,9 +184,9 @@ macro_rules! no_endianness_sized_uint_op {
 
 macro_rules! no_endianness_sized_int_op {
     ($env: expr, $read_op: ident, $op: ident, $write_op: ident) => {{
-        let a = stack_pop!($env);
         let b = stack_pop!($env);
-       
+        let a = stack_pop!($env);
+
         let mut a = Vec::from(a);
         a[0] ^= 1u8 << 7;
 
@@ -224,8 +224,8 @@ macro_rules! no_endianness_sized_int_op {
 
 macro_rules! sized_uint_op {
     ($env: expr, $read_op: ident, $op: ident, $write_op: ident) => {{
-        let mut a = stack_pop!($env);
         let mut b = stack_pop!($env);
+        let mut a = stack_pop!($env);
 
         let a_int = match a.$read_op::<BigEndian>() {
             Ok(v) => v,
@@ -256,8 +256,8 @@ macro_rules! sized_uint_op {
 
 macro_rules! sized_int_op {
     ($env: expr, $read_op: ident, $op: ident, $write_op: ident) => {{
-        let a = stack_pop!($env);
         let b = stack_pop!($env);
+        let a = stack_pop!($env);
 
         let mut a = Vec::from(a);
         a[0] ^= 1u8 << 7;


### PR DESCRIPTION
Running doctests skips over a number of doctests that are
defined, simply ignoring their existence.

Solution: the regular expression that was scanning for blocks
of tests did not account for empty lines.

Once this was addresses, it was discovered that a number of tests
actually fail, and this has been remedied as well.