### PR TITLE
Problem: server protocol has to be implemented afresh each time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "./pumpkinscript",
   "./pumpkindb_engine",
+  "./pumpkindb_client",
   "./pumpkindb_server",
   "./pumpkindb_term",
   "./tests/doctests"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ To name a few:
 
 | Language | Library | Status |
 |----------|---------|--------|
+| **Rust** | [pumpkindb_client](https://github.com/PumpkinDB/PumpkinDB/pumpkindb_client) | Pre-release |
 | **Java** | [pumpkindb-client](https://github.com/PumpkinDB/pumpkindb-java) | Pre-release |
 
 ## Trying it out

--- a/pumpkindb_client/Cargo.toml
+++ b/pumpkindb_client/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "pumpkindb_client"
+version = "0.2.0"
+license = "MPL-2.0"
+repository = "https://github.com/PumpkinDB/PumpkinDB"
+homepage = "http://pumpkindb.org"
+keywords = [ "pumpkindb", "database" ]
+categories = [ "database" ]
+
+authors = ["Yurii Rashkovskii <yrashk@gmail.com>"]
+
+[dependencies]
+byteorder = "1.0"
+pumpkinscript = { version = "0.2", path = "../pumpkinscript" }
+
+[dev-dependencies]

--- a/pumpkindb_client/src/lib.rs
+++ b/pumpkindb_client/src/lib.rs
@@ -1,0 +1,11 @@
+// Copyright (c) 2017, All Contributors (see CONTRIBUTORS file)
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+extern crate byteorder;
+extern crate pumpkinscript;
+
+mod packet;
+pub use packet::{PacketReader, PacketWriter};

--- a/pumpkindb_client/src/packet.rs
+++ b/pumpkindb_client/src/packet.rs
@@ -1,0 +1,89 @@
+// Copyright (c) 2017, All Contributors (see CONTRIBUTORS file)
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::io::{Write, Read};
+use std::io;
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+
+pub struct PacketWriter<T : Write>(T);
+
+impl<T : Write> PacketWriter<T> {
+    pub fn new(writer: T) -> Self {
+        PacketWriter(writer)
+    }
+    pub fn writer(self) -> T {
+        self.0
+    }
+}
+
+impl<T : Write> Write for PacketWriter<T> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self.0.write_u32::<BigEndian>(buf.len() as u32) {
+            Ok(()) => {
+               match self.0.write(buf) {
+                   Ok(sz) => Ok(sz + 4),
+                   Err(err) => Err(err),
+               }
+            },
+            Err(err) => Err(err),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+pub struct PacketReader<T : Read>(T);
+
+impl<T : Read> PacketReader<T> {
+    pub fn new(reader: T) -> Self {
+        PacketReader(reader)
+    }
+    pub fn reader(self) -> T {
+        self.0
+    }
+
+    pub fn read(&mut self) -> io::Result<Vec<u8>> {
+        match self.0.read_u32::<BigEndian>() {
+            Ok(size) => {
+                let mut buf = Vec::with_capacity(size as usize);
+                unsafe { buf.set_len(size as usize); }
+                match self.0.read(&mut buf) {
+                    Ok(_) => {
+                        Ok(buf)
+                    },
+                    Err(err) => Err(err),
+                }
+            },
+            Err(err) => Err(err),
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::{PacketWriter, PacketReader};
+    use std::io::{Write, Cursor};
+
+    #[test]
+    fn write() {
+        let v = vec![];
+        let mut w = PacketWriter::new(v);
+        let _ = w.write("hello".as_bytes()).unwrap();
+        let result = w.writer();
+        assert_eq!(result, vec![0,0,0,5,b'h',b'e',b'l',b'l',b'o']);
+    }
+
+    #[test]
+    fn read() {
+        let v = vec![0,0,0,5,b'h',b'e',b'l',b'l',b'o'];
+        let mut r = PacketReader::new(Cursor::new(v));
+        let result = r.read().unwrap();
+        assert_eq!(result, "hello".as_bytes());
+    }
+}

--- a/pumpkindb_term/Cargo.toml
+++ b/pumpkindb_term/Cargo.toml
@@ -18,7 +18,7 @@ rustyline = "1.0.0"
 ansi_term = "0.9.0"
 uuid = { version = "0.4.0", features = ["v4"] }
 clap = "2.22.1"
-byteorder = "1.0.0"
 
 pumpkinscript = { version = "0.2", path = "../pumpkinscript" }
 pumpkindb_engine = { version = "0.2", path = "../pumpkindb_engine" }
+pumpkindb_client = { version = "0.2", path = "../pumpkindb_client" }


### PR DESCRIPTION
Solution: extract pumpkindb_client crate with PacketWriter
and PacketReader that encapsulate the protocol mechanics for
Read and Write trait implementations.

Note that this won't work for futures-based approaches (Tokio, etc.)
for now. Something that can be improved further down the road.