### PR TITLE
Problem: no send/receive functionality in pumpkindb_client

### DIFF
--- a/pumpkindb_client/Cargo.toml
+++ b/pumpkindb_client/Cargo.toml
@@ -12,5 +12,3 @@ authors = ["Yurii Rashkovskii <yrashk@gmail.com>"]
 [dependencies]
 byteorder = "1.0"
 pumpkinscript = { version = "0.2", path = "../pumpkinscript" }
-
-[dev-dependencies]

--- a/pumpkindb_client/src/lib.rs
+++ b/pumpkindb_client/src/lib.rs
@@ -3,9 +3,54 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#![feature(fn_traits)]
 
 extern crate byteorder;
 extern crate pumpkinscript;
 
 mod packet;
 pub use packet::{PacketReader, PacketWriter};
+
+use std::io;
+use std::io::{Write, Read};
+pub use pumpkinscript::{Encodable, Receivable};
+
+pub trait Send {
+    fn send<E : Encodable>(&mut self, encodable: E) -> io::Result<()>;
+}
+
+impl<T : Write> Send for PacketWriter<T> {
+    fn send<E: Encodable>(&mut self, encodable: E) -> io::Result<()> {
+        self.write(&encodable.encode()).map(|_| ())
+    }
+}
+
+pub trait MessageHandler {
+    fn handle_message(&mut self, data: &[u8]);
+}
+
+impl<T : FnMut(&[u8])> MessageHandler for T {
+    fn handle_message(&mut self, data: &[u8]) {
+        self.call_mut((data,))
+    }
+}
+
+// This trait provides data receiving primitives
+pub trait Receive {
+    // Receive and handle one message. Returns after one message has
+    // been handled
+    fn receive<H : MessageHandler>(&mut self, handler: H) -> io::Result<()>;
+}
+
+impl<T : Read> Receive for T {
+    fn receive<H: MessageHandler>(&mut self, mut handler: H) -> io::Result<()> {
+        let mut reader = PacketReader::new(self);
+        match reader.read() {
+            Ok(data) => {
+                handler.handle_message(&data);
+                Ok(())
+            },
+            Err(err) => Err(err),
+        }
+    }
+}


### PR DESCRIPTION
This still forces end-user code to connect Encodables and
message receipt to Write and Read implementing types manually.

Solution: introduce Send and Receive traits in pumpkindb_client.

Also, re-export Encodable and Receivable through pumpkindb_client.