### PR TITLE
Problem: having to match lmdb version is onerous

### DIFF
--- a/pumpkindb_engine/src/crates.rs
+++ b/pumpkindb_engine/src/crates.rs
@@ -18,7 +18,7 @@ extern crate num_bigint;
 extern crate num_iter;
 extern crate num_traits;
 extern crate snowflake;
-extern crate lmdb_zero as lmdb;
+pub extern crate lmdb_zero as lmdb;
 #[cfg(test)]
 extern crate tempdir;
 #[cfg(test)]

--- a/pumpkindb_server/Cargo.toml
+++ b/pumpkindb_server/Cargo.toml
@@ -22,7 +22,6 @@ num_cpus = "1.3.0"
 memmap = "0.5.2"
 log = "0.3.6"
 log4rs = { version = "0.6.1", features = ["toml_format"] }
-lmdb-zero = "0.4.0"
 mio = "0.6.4"
 
 pumpkindb_engine = { version = "0.2", path = "../pumpkindb_engine" }

--- a/pumpkindb_server/src/main.rs
+++ b/pumpkindb_server/src/main.rs
@@ -15,12 +15,11 @@ extern crate memmap;
 #[macro_use]
 extern crate log;
 extern crate log4rs;
-extern crate lmdb_zero as lmdb;
 extern crate mio;
 
 extern crate pumpkindb_mio_server as server;
 
-use pumpkindb_engine::{script, storage, timestamp};
+use pumpkindb_engine::{script, storage, timestamp, lmdb};
 use pumpkindb_engine::script::dispatcher;
 use pumpkindb_engine::messaging;
 


### PR DESCRIPTION
In order to use pumpkindb_engine, one has to match
the version of lmdb it is using, and that adds complexity
to maintenace. First example of this is pumpkindb_server,
but other applications that use pumpkindb_engine, are
also affected.

Solution: let pumpkindb_engine re-export lmdb module.