### PR TITLE
Problem: HLC timestamp functionality is entangled with mmap

### DIFF
--- a/pumpkindb_engine/src/lib.rs
+++ b/pumpkindb_engine/src/lib.rs
@@ -16,3 +16,4 @@ pub mod script;
 pub mod messaging;
 pub mod storage;
 pub mod timestamp;
+pub mod nvmem;

--- a/pumpkindb_engine/src/nvmem.rs
+++ b/pumpkindb_engine/src/nvmem.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2017, All Contributors (see CONTRIBUTORS file)
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::io::{Read, Write};
+
+pub trait NonVolatileMemory : Read + Write {}
+
+use memmap::{Mmap, MmapViewSync, Protection};
+
+pub struct MmapedFile {
+    size: usize,
+    offset: usize,
+    mmap: Option<MmapViewSync>,
+}
+
+pub struct OutOfBoundsError;
+
+use std::path::PathBuf;
+use std::io;
+use std::fs::OpenOptions;
+
+impl MmapedFile {
+
+    pub fn new(path: PathBuf, size: usize) -> Result<Self, io::Error> {
+        let file = OpenOptions::new().create(true).write(true).open(path.as_path())?;
+        let _ = file.set_len(size as u64)?;
+        let mmap = Mmap::open_path(path.as_path(), Protection::ReadWrite)?;
+        Ok(MmapedFile{
+            size: size,
+            offset: 0,
+            mmap: Some(mmap.into_view_sync()),
+        })
+    }
+
+
+    pub fn new_anonymous(size: usize) -> Result<Self, io::Error> {
+        let mmap = Mmap::anonymous(size, Protection::ReadWrite)?;
+        Ok(MmapedFile{
+            size: size,
+            offset: 0,
+            mmap: Some(mmap.into_view_sync()),
+        })
+    }
+
+    pub fn claim(&mut self, len: usize) -> Result<MmapedRegion, io::Error> {
+        let (mut new_view, view) = ::std::mem::replace(&mut self.mmap, None).unwrap().split_at(self.offset + len)?;
+        new_view.restrict(0, len)?;
+        self.mmap = Some(view);
+        self.offset += len;
+        Ok(MmapedRegion {
+            mmap: new_view,
+            len: len,
+        })
+    }
+}
+
+pub struct MmapedRegion {
+    mmap: MmapViewSync,
+    len: usize,
+}
+
+impl Read for MmapedRegion {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        (unsafe { self.mmap.as_slice() }).read(buf)
+    }
+}
+
+impl Write for MmapedRegion {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        (unsafe { self.mmap.as_mut_slice() }).write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.mmap.flush()
+    }
+}
+
+impl<'a> NonVolatileMemory for MmapedRegion {}
+

--- a/pumpkindb_engine/src/script/mod.rs
+++ b/pumpkindb_engine/src/script/mod.rs
@@ -491,6 +491,7 @@ mod tests {
 
     use pumpkinscript::{parse, offset_by_size};
     use messaging;
+    use nvmem::{MmapedFile, MmapedRegion, NonVolatileMemory};
     use script::{Env, Scheduler, Error, RequestMessage, ResponseMessage, EnvId, dispatcher};
     use std::sync::mpsc;
     use std::sync::Arc;

--- a/pumpkindb_engine/src/script/mod_core.rs
+++ b/pumpkindb_engine/src/script/mod_core.rs
@@ -353,6 +353,7 @@ mod tests {
 
     use pumpkinscript::parse;
     use messaging;
+    use nvmem::{MmapedFile, MmapedRegion, NonVolatileMemory};
     use script::{Scheduler, RequestMessage, ResponseMessage, EnvId, dispatcher};
     use std::sync::mpsc;
     use std::sync::Arc;

--- a/pumpkindb_engine/src/script/mod_hlc.rs
+++ b/pumpkindb_engine/src/script/mod_hlc.rs
@@ -23,13 +23,14 @@ use hlc;
 use std::marker::PhantomData;
 use byteorder::{BigEndian, WriteBytesExt};
 use std::sync::Arc;
+use super::super::nvmem::NonVolatileMemory;
 
-pub struct Handler<'a> {
+pub struct Handler<'a, N> where N : NonVolatileMemory {
     phantom: PhantomData<&'a ()>,
-    timestamp: Arc<timestamp::Timestamp>,
+    timestamp: Arc<timestamp::Timestamp<N>>,
 }
 
-impl<'a> Dispatcher<'a> for Handler<'a> {
+impl<'a, N> Dispatcher<'a> for Handler<'a, N> where N : NonVolatileMemory {
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
         try_instruction!(env, self.handle_hlc(env, instruction, pid));
         try_instruction!(env, self.handle_hlc_lc(env, instruction, pid));
@@ -40,8 +41,8 @@ impl<'a> Dispatcher<'a> for Handler<'a> {
     }
 }
 
-impl<'a> Handler<'a> {
-    pub fn new(timestamp_state: Arc<timestamp::Timestamp>) -> Self {
+impl<'a, N> Handler<'a, N> where N : NonVolatileMemory {
+    pub fn new(timestamp_state: Arc<timestamp::Timestamp<N>>) -> Self {
         Handler {
             phantom: PhantomData,
             timestamp: timestamp_state,

--- a/pumpkindb_engine/src/script/mod_msg.rs
+++ b/pumpkindb_engine/src/script/mod_msg.rs
@@ -106,6 +106,7 @@ mod tests {
     use crossbeam;
     use storage;
     use timestamp;
+    use nvmem::{MmapedFile, MmapedRegion, NonVolatileMemory};
 
     use std::time::Duration;
 

--- a/pumpkindb_engine/src/script/mod_storage.rs
+++ b/pumpkindb_engine/src/script/mod_storage.rs
@@ -570,6 +570,7 @@ impl<'a> Handler<'a> {
 mod tests {
     use pumpkinscript::{parse, offset_by_size};
     use messaging;
+    use nvmem::{MmapedFile, MmapedRegion, NonVolatileMemory};
     use script::{Env, Scheduler, Error, RequestMessage, ResponseMessage, EnvId, dispatcher};
 
     use byteorder::WriteBytesExt;
@@ -630,7 +631,9 @@ mod tests {
             builder.set_mapsize(1024 * 1024 * 1024).expect("can't set mapsize");
             builder.open(path, lmdb::open::NOTLS, 0o600).expect("can't open env")
         };
-        let timestamp = timestamp::Timestamp::new(None);
+        let mut nvmem = MmapedFile::new_anonymous(20).unwrap();
+        let region = nvmem.claim(20).unwrap();
+        let timestamp = Arc::new(timestamp::Timestamp::new(region));
         let db = storage::Storage::new(&env);
         b.iter(move || {
             let mut timestamps = Vec::new();

--- a/pumpkindb_engine/src/timestamp.rs
+++ b/pumpkindb_engine/src/timestamp.rs
@@ -6,45 +6,36 @@
 
 use hlc;
 use std::sync::Mutex;
-use memmap::{MmapViewSync, Mmap, Protection};
+use super::nvmem::NonVolatileMemory;
 
 #[derive(Debug)]
-pub struct Timestamp {
-    clock: Mutex<(hlc::Clock<hlc::Wall>, MmapViewSync)>,
+pub struct Timestamp<N : NonVolatileMemory> {
+    clock: Mutex<(hlc::Clock<hlc::Wall>, N)>,
 }
 
-impl Timestamp {
+impl<N : NonVolatileMemory> Timestamp<N> {
     /// Create a new Timestamp clock. First the passed in memory map will be checked to check if
     /// a previous timestamp exists. If one exists (i.e. if the results aren't 20 bytes of 0) it
     /// will be "observed" by the HLC library.
-    pub fn new(scratchpad: Option<MmapViewSync>) -> Self {
-        if scratchpad.is_some() {
-            let scratchpad = scratchpad.unwrap();
-            let clock = {
-                let mut clock = hlc::Clock::wall();
-                let previous = unsafe { scratchpad.as_slice() };
-                let res = hlc::Timestamp::read_bytes(previous);
-                if res.is_ok() {
-                    let res = res.unwrap();
-                    if res > clock.now() {
-                        let _ = clock.observe(&res);
-                    }
+    pub fn new(mut nvmem: N) -> Self {
+        let clock = {
+            let mut clock = hlc::Clock::wall();
+            let res = hlc::Timestamp::read_bytes(&mut nvmem);
+            if res.is_ok() {
+                let res = res.unwrap();
+                if res > clock.now() {
+                    let _ = clock.observe(&res);
                 }
-                clock
-            };
-            Timestamp { clock: Mutex::new((clock, scratchpad)) }
-        } else {
-            let clock = hlc::Clock::wall();
-            let scratchpad = Mmap::anonymous(20, Protection::ReadWrite).unwrap();
-            Timestamp { clock: Mutex::new((clock, scratchpad.into_view_sync())) }
-        }
+            }
+            clock
+        };
+        Timestamp { clock: Mutex::new((clock, nvmem)) }
     }
 
     pub fn hlc(&self) -> hlc::Timestamp<hlc::WallT> {
         let mut clock = self.clock.lock().unwrap();
         let now = clock.0.now();
-        let ref mut state = clock.1;
-        let _ = unsafe { &now.write_bytes(&mut state.as_mut_slice()).unwrap() };
+        let _ = &now.write_bytes(&mut clock.1).unwrap();
         now
     }
 
@@ -52,9 +43,7 @@ impl Timestamp {
         let mut clock = self.clock.lock().unwrap();
         match clock.0.observe(&other_time) {
             Ok(_) => {
-                let _ = unsafe { 
-                    clock.0.now().write_bytes(&mut clock.1.as_mut_slice()).unwrap() 
-                };
+                let _ = clock.0.now().write_bytes(&mut clock.1).unwrap();
                 Ok(())
             },
             Err(_) => Err(())
@@ -64,13 +53,15 @@ impl Timestamp {
 
 #[cfg(test)]
 mod tests {
-    use memmap::{Mmap, Protection};
+    use nvmem::{NonVolatileMemory, MmapedFile};
     use timestamp::Timestamp;
     use hlc;
 
     #[test]
     fn order_guaranteed() {
-        let timestamp = Timestamp::new(None);
+        let mut nvmem = MmapedFile::new_anonymous(20).unwrap();
+        let region = nvmem.claim(20).unwrap();
+        let timestamp = Timestamp::new(region);
         let p1 = timestamp.hlc();
         let p2 = timestamp.hlc();
         assert!(p2 > p1);
@@ -83,13 +74,13 @@ mod tests {
         // timestamp. Two stamps are then taken, and we make sure that even with a timestamp "from
         // the future" as being the last known timestamp, the invariant that HLC moves forward (and
         // is ordered that way) holds.
-        let mut scratchpad = Mmap::anonymous(20, Protection::ReadWrite).unwrap();
+        let mut nvmem = MmapedFile::new_anonymous(20).unwrap();
         let mut clock = hlc::Clock::wall();
         clock.set_epoch(u32::max_value());
         let now = clock.now();
-        let _ = unsafe { &now.write_bytes(&mut scratchpad.as_mut_slice()).unwrap() };
-        let sync_view = scratchpad.into_view_sync();
-        let timestamp = Timestamp::new(Some(sync_view));
+        let mut region = nvmem.claim(20).unwrap();
+        let _ = &now.write_bytes(&mut region).unwrap();
+        let timestamp = Timestamp::new(region);
         let p1 = timestamp.hlc();
         let p2 = timestamp.hlc();
         assert!(p1 < p2);
@@ -98,7 +89,9 @@ mod tests {
     
     #[test]
     fn observe_updates_hlc() {
-        let timestamp = Timestamp::new(None);
+        let mut nvmem = MmapedFile::new_anonymous(20).unwrap();
+        let region = nvmem.claim(20).unwrap();
+        let timestamp = Timestamp::new(region);
         let t0 = timestamp.hlc();
         let mut wall_clock = hlc::Clock::wall();
         let wall_epoch = t0.epoch + 1;
@@ -114,7 +107,9 @@ mod tests {
 
     #[bench]
     fn timestamp_generation(b: &mut Bencher) {
-        let timestamp = Timestamp::new(None);
+        let mut nvmem = MmapedFile::new_anonymous(20).unwrap();
+        let region = nvmem.claim(20).unwrap();
+        let timestamp = Timestamp::new(region);
         b.iter(|| timestamp.hlc());
     }
 }

--- a/pumpkindb_server/Cargo.toml
+++ b/pumpkindb_server/Cargo.toml
@@ -19,7 +19,6 @@ clap = "2.22.1"
 config = "0.3.1"
 lazy_static = "0.2.2"
 num_cpus = "1.3.0"
-memmap = "0.5.2"
 log = "0.3.6"
 log4rs = { version = "0.6.1", features = ["toml_format"] }
 mio = "0.6.4"


### PR DESCRIPTION
This cohesion is not healthy as it makes one serious assumption
as to where this HLC should be stored.

Solution: extract a NonVolatileMemory trait and MmapedFile/Region
structs so that HLC timestamp wouldn't need to know how this storage
is implemented.