### PR TITLE
Problem: Travis CI and AppVeyor are set to test on an old nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - stable
-  - nightly-2017-05-04
+  - nightly-2017-06-19
 matrix:
   allow_failures:
     - rust: stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   matrix:
     - channel: stable
       target: x86_64-pc-windows-msvc
-    - channel: nightly-2017-05-04
+    - channel: nightly-2017-06-19
       target: x86_64-pc-windows-msvc
 
 matrix:


### PR DESCRIPTION
That nightly is more than a month old.

Solution: switch to a more up-to-date nightly