### PR TITLE
Problem: accessing random scheduler requires extra code

### DIFF
--- a/pumpkindb_engine/src/script/dispatcher.rs
+++ b/pumpkindb_engine/src/script/dispatcher.rs
@@ -181,7 +181,7 @@ mod tests {
 
   use pumpkinscript::parse;
   use script::{Env, EnvId, PassResult,
-               Scheduler, Error, RequestMessage, ResponseMessage,
+               Scheduler, SchedulerHandle, Error, RequestMessage, ResponseMessage,
                Dispatcher};
   use std::sync::mpsc;
   use crossbeam;
@@ -227,8 +227,7 @@ mod tests {
           let script = parse("TEST").unwrap();
           let (callback, receiver) = mpsc::channel::<ResponseMessage>();
           let (sender0, _) = mpsc::channel();
-          let _ = sender.send(RequestMessage::ScheduleEnv(EnvId::new(), script.clone(),
-                                                          callback, Box::new(sender0)));
+          sender.schedule_env(EnvId::new(), script.clone(), callback, Box::new(sender0));
           match receiver.recv() {
               Ok(ResponseMessage::EnvTerminated(_, stack, stack_size)) => {
                   // terminated without an error
@@ -249,7 +248,7 @@ mod tests {
                   panic!("recv error: {:?}", err);
              }
          }
-         let _ = sender_.send(RequestMessage::Shutdown);
+         sender_.shutdown();
          let _ = handle.join();
     });
   }


### PR DESCRIPTION
Solution: abstract Env scheduling into the SchedulerHandle
trait so that any structure can be used as a handle to a scheduler.

This way, a simple Sender will always pick the scheduler
at the other end of the channel, and a vector of Senders will
schedule through a randomly channel.