### PR TITLE
Problem: PassResult visibility prevents embedding apps from using it

### DIFF
--- a/pumpkindb_engine/src/script/mod.rs
+++ b/pumpkindb_engine/src/script/mod.rs
@@ -241,7 +241,7 @@ pub struct Scheduler<'a, T : Dispatcher<'a>> {
 
 unsafe impl<'a, T : Dispatcher<'a>> Send for Scheduler<'a, T> {}
 
-type PassResult<'a> = Result<(), Error>;
+pub type PassResult<'a> = Result<(), Error>;
 
 const STACK_TRUE: &'static [u8] = b"\x01";
 const STACK_FALSE: &'static [u8] = b"\x00";


### PR DESCRIPTION
It is impossible to define handlers that would use it.

Solution: make PassResult public