### PR TITLE
Problem: no way to identify transaction boundaries

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -51,6 +51,7 @@
    * [CURSOR/VAL](script/CURSOR/VAL.md)
    * [READ](script/READ.md)
    * [RETR](script/RETR.md)
+   * [TXID](script/TXID.md)
    * [WRITE](script/WRITE.md)
  * Binaries
    * [CONCAT](script/CONCAT.md)

--- a/doc/script/TXID.md
+++ b/doc/script/TXID.md
@@ -1,0 +1,43 @@
+# TXID
+
+{% method -%}
+
+Pushes current transaction's identifier onto the top of the stack 
+
+Input stack: -
+
+Output stack: `transaction id`
+
+In certain cases it is worthwhile to learn whether some data was recorded
+within the boundaries of the same transaction as other. This instruction allows
+to do this by retrieving ongoing transaction's ID
+
+Transaction identifiers are guaranteed to be unique and grow monotonically,
+thus allowing one to compare the order of their origination.
+
+{% common -%}
+
+```
+PumpkinDB> [ TXID ] READ.
+0x0000000014cbed8aff34dc5000000000
+```
+
+{% endmethod %}
+
+## Allocation
+
+None
+
+## Errors
+
+[NoTransaction](./errors/NoTransaction.md) error if there's no ongoing transaction.
+
+## Tests
+
+```test
+read : [TXID] READ SOME?.
+write : [TXID] WRITE SOME?.
+same_within_tx : [TXID TXID] WRITE EQUAL?.
+ordering : [TXID] WRITE [TXID] WRITE LT?.
+requires_txn : [TXID] TRY UNWRAP 0x08 EQUAL?.
+```

--- a/pumpkindb_engine/src/script/dispatcher.rs
+++ b/pumpkindb_engine/src/script/dispatcher.rs
@@ -110,7 +110,7 @@ pub struct StandardDispatcher<'a, P: 'a, S: 'a, N: 'a, T>
     #[cfg(feature = "mod_numbers")]
     numbers: mod_numbers::Handler<'a>,
     #[cfg(feature = "mod_storage")]
-    storage: mod_storage::Handler<'a, T>,
+    storage: mod_storage::Handler<'a, T, N>,
     #[cfg(feature = "mod_hash")]
     hash: mod_hash::Handler<'a>,
     #[cfg(feature = "mod_hlc")]
@@ -144,7 +144,7 @@ impl<'a, P: 'a, S: 'a, N: 'a, T> StandardDispatcher<'a, P, S, N, T>
                 #[cfg(feature = "mod_numbers")]
                     numbers: mod_numbers::Handler::new(),
                 #[cfg(feature = "mod_storage")]
-                    storage: mod_storage::Handler::new(db),
+                    storage: mod_storage::Handler::new(db, timestamp_state.clone()),
                 #[cfg(feature = "mod_hash")]
                     hash: mod_hash::Handler::new(),
                 #[cfg(feature = "mod_hlc")]


### PR DESCRIPTION
In certain cases it is worthwhile to learn whether some data was recorded
within the boundaries of the same transaction as other.

Solution: introduce TXID instruction that allows to do this by retrieving
ongoing transaction's ID. Transaction identifiers are guaranteed to be unique
and grow monotonically, thus allowing one to compare the order of their origination.