### PR TITLE
Problem: maintaining lmdb version across crates is inefficient

### DIFF
--- a/pumpkindb_mio_server/Cargo.toml
+++ b/pumpkindb_mio_server/Cargo.toml
@@ -20,7 +20,6 @@ num-traits = "0.1.36"
 rand = "0.3.15"
 log = "0.3.6"
 log4rs = { version = "0.6.1", features = ["toml_format"] }
-lmdb-zero = "0.4.0"
 uuid = { version = "0.4", features = ["v4"] }
 
 pumpkindb_engine = { version = "0.2", path = "../pumpkindb_engine" }

--- a/pumpkindb_mio_server/src/lib.rs
+++ b/pumpkindb_mio_server/src/lib.rs
@@ -15,7 +15,6 @@ extern crate log4rs;
 extern crate slab;
 extern crate num_bigint;
 extern crate num_traits;
-extern crate lmdb_zero as lmdb;
 extern crate uuid;
 
 extern crate pumpkindb_engine;
@@ -28,7 +27,7 @@ use mio::tcp::TcpListener;
 
 use mio::channel as mio_chan;
 
-use pumpkindb_engine::script;
+use pumpkindb_engine::{script, lmdb};
 
 pub fn run(port: i64,
            senders: Vec<script::Sender<script::RequestMessage>>,

--- a/tests/doctests/Cargo.toml
+++ b/tests/doctests/Cargo.toml
@@ -11,7 +11,6 @@ glob = "0.2.11"
 regex = "0.2.1"
 crossbeam = "0.2.10"
 tempdir = "0.3.5"
-lmdb-zero = "0.4.0"
 
 pumpkinscript = { version = "0.2", path = "../../pumpkinscript" }
 pumpkindb_engine = { version = "0.2", path = "../../pumpkindb_engine" }

--- a/tests/doctests/src/main.rs
+++ b/tests/doctests/src/main.rs
@@ -12,7 +12,6 @@ extern crate glob;
 extern crate regex;
 extern crate crossbeam;
 extern crate tempdir;
-extern crate lmdb_zero as lmdb;
 
 extern crate pumpkinscript;
 extern crate pumpkindb_engine;
@@ -29,7 +28,7 @@ use tempdir::TempDir;
 
 use pumpkindb_engine::script::{SchedulerHandle, ResponseMessage, EnvId, Env, Scheduler, dispatcher};
 use pumpkinscript::{textparser, binparser};
-use pumpkindb_engine::{messaging, storage, timestamp, nvmem};
+use pumpkindb_engine::{messaging, storage, timestamp, nvmem, lmdb};
 
 fn eval(name: &[u8], script: &[u8], timestamp: Arc<timestamp::Timestamp<nvmem::MmapedRegion>>) {
     let dir = TempDir::new("pumpkindb").unwrap();


### PR DESCRIPTION
Some of the crates depend on lmdb-zero crate independently, meaning
once it'll need to get upgraded, all dependencies will need to be
updated as well.

Solution: use pumpkindb_engine's re-export of lmdb to be consistent