### PR TITLE
Problem: instructions handling macros are obscure

### DIFF
--- a/pumpkindb_engine/src/lib.rs
+++ b/pumpkindb_engine/src/lib.rs
@@ -5,6 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #![feature(slice_patterns, advanced_slice_patterns)]
 #![feature(struct_field_attributes)]
+#![feature(try_trait)]
 
 #![cfg_attr(test, feature(test))]
 #![cfg_attr(not(target_os = "windows"), feature(alloc, heap_api))]

--- a/pumpkindb_engine/src/lib.rs
+++ b/pumpkindb_engine/src/lib.rs
@@ -5,7 +5,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #![feature(slice_patterns, advanced_slice_patterns)]
 #![feature(struct_field_attributes)]
-#![feature(try_trait)]
 
 #![cfg_attr(test, feature(test))]
 #![cfg_attr(not(target_os = "windows"), feature(alloc, heap_api))]

--- a/pumpkindb_engine/src/script/dispatcher.rs
+++ b/pumpkindb_engine/src/script/dispatcher.rs
@@ -199,7 +199,7 @@ mod tests {
   use pumpkinscript::parse;
   use script::{Env, EnvId, PassResult,
                Scheduler, SchedulerHandle, Error, RequestMessage, ResponseMessage,
-               Dispatcher, InstructionIs, TryInstruction};
+               Dispatcher, TryInstruction};
   use std::sync::mpsc;
   use crossbeam;
 
@@ -217,7 +217,7 @@ mod tests {
 
       pub fn handle_test(&mut self, env: &mut Env<'a>,
                           instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-          InstructionIs(instruction, b"\x84TEST")?;
+          return_unless_instructions_equal!(instruction, b"\x84TEST");
           env.push(b"TEST");
           Ok(())
       }

--- a/pumpkindb_engine/src/script/dispatcher.rs
+++ b/pumpkindb_engine/src/script/dispatcher.rs
@@ -5,6 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use super::*;
+use std::iter::Iterator;
 
 pub trait Dispatcher<'a> {
     #[allow(unused_variables)]
@@ -28,8 +29,18 @@ impl<'a> Dispatcher<'a> for Vec<Box<Dispatcher<'a>>> {
         }
     }
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
-        for mut disp in self.into_iter() {
-            try_instruction!(env, disp.handle(env, instruction, pid));
+        let mut iter = self.into_iter();
+        while true {
+            match iter.next() {
+                None => break,
+                Some(mut disp) => {
+                    let result = disp.handle(env, instruction, pid);
+                    if result.is_unhandled() {
+                        continue
+                    }
+                    return result;
+                }
+            }
         }
         Err(Error::UnknownInstruction)
     }
@@ -171,7 +182,12 @@ impl<'a, P: 'a, S: 'a, N: 'a, T> Dispatcher<'a> for StandardDispatcher<'a, P, S,
         for_each_dispatcher!(disp, self, disp.done(env, pid));
     }
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
-        for_each_dispatcher!(disp, self, try_instruction!(env, disp.handle(env, instruction, pid)));
+        for_each_dispatcher!(disp, self, {
+           let result = disp.handle(env, instruction, pid);
+           if !result.is_unhandled() {
+              return result;
+           }
+        });
         Err(Error::UnknownInstruction)
     }
 }
@@ -183,7 +199,7 @@ mod tests {
   use pumpkinscript::parse;
   use script::{Env, EnvId, PassResult,
                Scheduler, SchedulerHandle, Error, RequestMessage, ResponseMessage,
-               Dispatcher};
+               Dispatcher, InstructionIs, TryInstruction};
   use std::sync::mpsc;
   use crossbeam;
 
@@ -201,7 +217,7 @@ mod tests {
 
       pub fn handle_test(&mut self, env: &mut Env<'a>,
                           instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-          instruction_is!(instruction, b"\x84TEST");
+          InstructionIs(instruction, b"\x84TEST")?;
           env.push(b"TEST");
           Ok(())
       }
@@ -210,8 +226,8 @@ mod tests {
 
   impl<'a> Dispatcher<'a> for MyDispatcher<'a> {
      fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
-         try_instruction!(env, self.handle_test(env, instruction, pid));
-         Err(Error::UnknownInstruction)
+         self.handle_test(env, instruction, pid)
+             .if_unhandled_try(|| Err(Error::UnknownInstruction))
      }
   }
 

--- a/pumpkindb_engine/src/script/macros.rs
+++ b/pumpkindb_engine/src/script/macros.rs
@@ -65,18 +65,6 @@ macro_rules! handle_error {
 }
 
 #[macro_export]
-macro_rules! try_instruction {
-  ($env: expr, $handler : expr) => {
-    match $handler {
-        Err(Error::UnknownInstruction) => (),
-        Err(err @ Error::ProgramError(_)) => return handle_error!($env, err),
-        Err(err) => return Err(err),
-        Ok(()) => return Ok(())
-    }
-  };
-}
-
-#[macro_export]
 macro_rules! stack_pop {
     ($env: expr) => {
         match $env.pop() {
@@ -88,15 +76,6 @@ macro_rules! stack_pop {
             }
         }
     }
-}
-
-#[macro_export]
-macro_rules! instruction_is {
-    ($instruction: expr, $exp: expr) => {
-        if $instruction != $exp {
-            return Err(Error::UnknownInstruction)
-        }
-    };
 }
 
 #[macro_export]

--- a/pumpkindb_engine/src/script/macros.rs
+++ b/pumpkindb_engine/src/script/macros.rs
@@ -79,6 +79,15 @@ macro_rules! stack_pop {
 }
 
 #[macro_export]
+macro_rules! return_unless_instructions_equal {
+    ($instruction: expr, $exp: expr) => {
+        if $instruction != $exp {
+            return Err(Error::UnknownInstruction)
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! error_program {
     ($desc: expr, $details: expr, $code: expr) => {{
         let mut error = Vec::new();

--- a/pumpkindb_engine/src/script/mod_binaries.rs
+++ b/pumpkindb_engine/src/script/mod_binaries.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
-            offset_by_size, STACK_TRUE, STACK_FALSE};
+            offset_by_size, STACK_TRUE, STACK_FALSE, InstructionIs, TryInstruction};
 
 use std::marker::PhantomData;
 
@@ -29,15 +29,15 @@ builtins!("mod_binaries.builtins");
 
 impl<'a> Dispatcher<'a> for Handler<'a> {
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
-        try_instruction!(env, self.handle_builtins(env, instruction, pid));
-        try_instruction!(env, self.handle_ltp(env, instruction, pid));
-        try_instruction!(env, self.handle_gtp(env, instruction, pid));
-        try_instruction!(env, self.handle_equal(env, instruction, pid));
-        try_instruction!(env, self.handle_concat(env, instruction, pid));
-        try_instruction!(env, self.handle_slice(env, instruction, pid));
-        try_instruction!(env, self.handle_pad(env, instruction, pid));
-        try_instruction!(env, self.handle_length(env, instruction, pid));
-        Err(Error::UnknownInstruction)
+        self.handle_builtins(env, instruction, pid)
+        .if_unhandled_try(|| self.handle_ltp(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_gtp(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_equal(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_concat(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_slice(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_pad(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_length(env, instruction, pid))
+        .if_unhandled_try(|| Err(Error::UnknownInstruction))
     }
 }
 
@@ -54,7 +54,7 @@ impl<'a> Handler<'a> {
                     instruction: &'a [u8],
                     _: EnvId)
                     -> PassResult<'a> {
-        instruction_is!(instruction, EQUALQ);
+        InstructionIs(instruction, EQUALQ)?;
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -69,7 +69,7 @@ impl<'a> Handler<'a> {
 
     #[inline]
     fn handle_ltp(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        instruction_is!(instruction, LTQ);
+        InstructionIs(instruction, LTQ)?;
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -84,7 +84,7 @@ impl<'a> Handler<'a> {
 
     #[inline]
     fn handle_gtp(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        instruction_is!(instruction, GTQ);
+        InstructionIs(instruction, GTQ)?;
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -103,7 +103,7 @@ impl<'a> Handler<'a> {
                      instruction: &'a [u8],
                      _: EnvId)
                      -> PassResult<'a> {
-        instruction_is!(instruction, CONCAT);
+        InstructionIs(instruction, CONCAT)?;
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -123,7 +123,7 @@ impl<'a> Handler<'a> {
                     instruction: &'a [u8],
                     _: EnvId)
                     -> PassResult<'a> {
-        instruction_is!(instruction, SLICE);
+        InstructionIs(instruction, SLICE)?;
         let end = stack_pop!(env);
         let start = stack_pop!(env);
         let slice = stack_pop!(env);
@@ -151,7 +151,7 @@ impl<'a> Handler<'a> {
 
     #[inline]
     fn handle_pad(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        instruction_is!(instruction, PAD);
+        InstructionIs(instruction, PAD)?;
         let byte = stack_pop!(env);
         let size = stack_pop!(env);
         let value = stack_pop!(env);
@@ -188,7 +188,7 @@ impl<'a> Handler<'a> {
                      instruction: &'a [u8],
                      _: EnvId)
                      -> PassResult<'a> {
-        instruction_is!(instruction, LENGTH);
+        InstructionIs(instruction, LENGTH)?;
         let a = stack_pop!(env);
 
         let len = BigUint::from(a.len() as u64);

--- a/pumpkindb_engine/src/script/mod_binaries.rs
+++ b/pumpkindb_engine/src/script/mod_binaries.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
-            offset_by_size, STACK_TRUE, STACK_FALSE, InstructionIs, TryInstruction};
+            offset_by_size, STACK_TRUE, STACK_FALSE, TryInstruction};
 
 use std::marker::PhantomData;
 
@@ -54,7 +54,7 @@ impl<'a> Handler<'a> {
                     instruction: &'a [u8],
                     _: EnvId)
                     -> PassResult<'a> {
-        InstructionIs(instruction, EQUALQ)?;
+        return_unless_instructions_equal!(instruction, EQUALQ);
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -69,7 +69,7 @@ impl<'a> Handler<'a> {
 
     #[inline]
     fn handle_ltp(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        InstructionIs(instruction, LTQ)?;
+        return_unless_instructions_equal!(instruction, LTQ);
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -84,7 +84,7 @@ impl<'a> Handler<'a> {
 
     #[inline]
     fn handle_gtp(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        InstructionIs(instruction, GTQ)?;
+        return_unless_instructions_equal!(instruction, GTQ);
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -103,7 +103,7 @@ impl<'a> Handler<'a> {
                      instruction: &'a [u8],
                      _: EnvId)
                      -> PassResult<'a> {
-        InstructionIs(instruction, CONCAT)?;
+        return_unless_instructions_equal!(instruction, CONCAT);
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -123,7 +123,7 @@ impl<'a> Handler<'a> {
                     instruction: &'a [u8],
                     _: EnvId)
                     -> PassResult<'a> {
-        InstructionIs(instruction, SLICE)?;
+        return_unless_instructions_equal!(instruction, SLICE);
         let end = stack_pop!(env);
         let start = stack_pop!(env);
         let slice = stack_pop!(env);
@@ -151,7 +151,7 @@ impl<'a> Handler<'a> {
 
     #[inline]
     fn handle_pad(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        InstructionIs(instruction, PAD)?;
+        return_unless_instructions_equal!(instruction, PAD);
         let byte = stack_pop!(env);
         let size = stack_pop!(env);
         let value = stack_pop!(env);
@@ -188,7 +188,7 @@ impl<'a> Handler<'a> {
                      instruction: &'a [u8],
                      _: EnvId)
                      -> PassResult<'a> {
-        InstructionIs(instruction, LENGTH)?;
+        return_unless_instructions_equal!(instruction, LENGTH);
         let a = stack_pop!(env);
 
         let len = BigUint::from(a.len() as u64);

--- a/pumpkindb_engine/src/script/mod_core.rs
+++ b/pumpkindb_engine/src/script/mod_core.rs
@@ -7,7 +7,7 @@
 use pumpkinscript::{parse_bin, binparser};
 
 use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
-            offset_by_size, STACK_TRUE, STACK_FALSE, InstructionIs, TryInstruction};
+            offset_by_size, STACK_TRUE, STACK_FALSE, TryInstruction};
 
 use std::marker::PhantomData;
 
@@ -74,7 +74,7 @@ impl<'a> Handler<'a> {
 
     #[inline]
     fn handle_not(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        InstructionIs(instruction, NOT)?;
+        return_unless_instructions_equal!(instruction, NOT);
         let a = stack_pop!(env);
 
         if a == STACK_TRUE {
@@ -90,7 +90,7 @@ impl<'a> Handler<'a> {
 
     #[inline]
     fn handle_and(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        InstructionIs(instruction, AND)?;
+        return_unless_instructions_equal!(instruction, AND);
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -112,7 +112,7 @@ impl<'a> Handler<'a> {
 
     #[inline]
     fn handle_or(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        InstructionIs(instruction, OR)?;
+        return_unless_instructions_equal!(instruction, OR);
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -138,7 +138,7 @@ impl<'a> Handler<'a> {
                      instruction: &'a [u8],
                      _: EnvId)
                      -> PassResult<'a> {
-        InstructionIs(instruction, IFELSE)?;
+        return_unless_instructions_equal!(instruction, IFELSE);
         let else_ = stack_pop!(env);
         let then = stack_pop!(env);
         let cond = stack_pop!(env);
@@ -161,7 +161,7 @@ impl<'a> Handler<'a> {
                           instruction: &'a [u8],
                           _: EnvId)
                           -> PassResult<'a> {
-        InstructionIs(instruction, EVAL_SCOPED)?;
+        return_unless_instructions_equal!(instruction, EVAL_SCOPED);
         env.push_dictionary();
         let a = stack_pop!(env);
         env.program.push(SCOPE_END);
@@ -183,7 +183,7 @@ impl<'a> Handler<'a> {
                         instruction: &'a [u8],
                         _: EnvId)
                         -> PassResult<'a> {
-        InstructionIs(instruction, SCOPE_END)?;
+        return_unless_instructions_equal!(instruction, SCOPE_END);
         env.pop_dictionary();
         Ok(())
     }
@@ -201,7 +201,7 @@ impl<'a> Handler<'a> {
                    instruction: &'a [u8],
                    _: EnvId)
                    -> PassResult<'a> {
-        InstructionIs(instruction, EVAL)?;
+        return_unless_instructions_equal!(instruction, EVAL);
         let a = stack_pop!(env);
         env.program.push(a);
         Ok(())
@@ -213,7 +213,7 @@ impl<'a> Handler<'a> {
                           instruction: &'a [u8],
                           _: EnvId)
                           -> PassResult<'a> {
-        InstructionIs(instruction, EVAL_VALIDP)?;
+        return_unless_instructions_equal!(instruction, EVAL_VALIDP);
         let a = stack_pop!(env);
         if parse_bin(a).is_ok() {
             env.push(STACK_TRUE);
@@ -229,7 +229,7 @@ impl<'a> Handler<'a> {
                       instruction: &'a [u8],
                       _: EnvId)
                       -> PassResult<'a> {
-        InstructionIs(instruction, DOWHILE)?;
+        return_unless_instructions_equal!(instruction, DOWHILE);
         let v = stack_pop!(env);
 
         let mut vec = Vec::new();
@@ -264,7 +264,7 @@ impl<'a> Handler<'a> {
                     instruction: &'a [u8],
                     _: EnvId)
                     -> PassResult<'a> {
-        InstructionIs(instruction, TIMES)?;
+        return_unless_instructions_equal!(instruction, TIMES);
         let count = stack_pop!(env);
 
         let v = stack_pop!(env);
@@ -279,7 +279,7 @@ impl<'a> Handler<'a> {
 
     #[inline]
     fn handle_set(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        InstructionIs(instruction, SET)?;
+        return_unless_instructions_equal!(instruction, SET);
         let instruction = stack_pop!(env);
         let value = stack_pop!(env);
         match binparser::instruction(instruction) {
@@ -304,7 +304,7 @@ impl<'a> Handler<'a> {
 
     #[inline]
     fn handle_def(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        InstructionIs(instruction, DEF)?;
+        return_unless_instructions_equal!(instruction, DEF);
         let instruction = stack_pop!(env);
         let value = stack_pop!(env);
         match binparser::instruction(instruction) {
@@ -330,7 +330,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, FEATUREQ)?;
+        return_unless_instructions_equal!(instruction, FEATUREQ);
         let name = stack_pop!(env);
 
         #[cfg(feature = "scoped_dictionary")]

--- a/pumpkindb_engine/src/script/mod_hash.rs
+++ b/pumpkindb_engine/src/script/mod_hash.rs
@@ -25,7 +25,7 @@ instruction!(HASH_SHA512_256, b"\x8FHASH/SHA512-256");
 // `Sha512Trunc256`, which is the 64-bit `Sha512` algorithm with the result truncated to 256 bits.
 //
 
-use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, offset_by_size, InstructionIs,
+use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, offset_by_size,
             TryInstruction};
 use crypto::digest::Digest;
 use crypto::sha1::Sha1;
@@ -41,7 +41,7 @@ macro_rules! hash_instruction {
     ($name : ident, $constant: ident, $i: ident, $size: expr) => {
     #[inline]
     pub fn $name(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        InstructionIs(instruction, $constant)?;
+        return_unless_instructions_equal!(instruction, $constant);
         let a = stack_pop!(env);
         let mut hasher = $i::new();
         hasher.input(a);

--- a/pumpkindb_engine/src/script/mod_hlc.rs
+++ b/pumpkindb_engine/src/script/mod_hlc.rs
@@ -16,7 +16,7 @@ instruction!(HLC_TICK, b"\x88HLC/TICK");
 instruction!(HLC_OBSERVE, b"\x8BHLC/OBSERVE");
 
 use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
-            offset_by_size};
+            offset_by_size, InstructionIs, TryInstruction};
 use timestamp;
 
 use hlc;
@@ -32,12 +32,11 @@ pub struct Handler<'a, N> where N : NonVolatileMemory {
 
 impl<'a, N> Dispatcher<'a> for Handler<'a, N> where N : NonVolatileMemory {
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
-        try_instruction!(env, self.handle_hlc(env, instruction, pid));
-        try_instruction!(env, self.handle_hlc_lc(env, instruction, pid));
-        try_instruction!(env, self.handle_hlc_tick(env, instruction, pid));
-        try_instruction!(env, self.handle_hlc_observe(env, instruction, pid));
-
-        Err(Error::UnknownInstruction)
+        self.handle_hlc(env, instruction, pid)
+        .if_unhandled_try(|| self.handle_hlc_lc(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_hlc_tick(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_hlc_observe(env, instruction, pid))
+        .if_unhandled_try(|| Err(Error::UnknownInstruction))
     }
 }
 
@@ -51,7 +50,7 @@ impl<'a, N> Handler<'a, N> where N : NonVolatileMemory {
 
     #[inline]
     pub fn handle_hlc(&self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        instruction_is!(instruction, HLC);
+        InstructionIs(instruction, HLC)?;
         let now = self.timestamp.hlc();
         let slice = alloc_slice!(16, env);
         let _ = now.write_bytes(&mut slice[0..]).unwrap();
@@ -65,7 +64,7 @@ impl<'a, N> Handler<'a, N> where N : NonVolatileMemory {
                            instruction: &'a [u8],
                            _: EnvId)
                            -> PassResult<'a> {
-        instruction_is!(instruction, HLC_TICK);
+        InstructionIs(instruction, HLC_TICK)?;
 
         let a = env.pop();
 
@@ -97,7 +96,7 @@ impl<'a, N> Handler<'a, N> where N : NonVolatileMemory {
                          instruction: &'a [u8],
                          _: EnvId)
                          -> PassResult<'a> {
-        instruction_is!(instruction, HLC_LC);
+        InstructionIs(instruction, HLC_LC)?;
         let a = env.pop();
 
         if a.is_none() {
@@ -128,7 +127,7 @@ impl<'a, N> Handler<'a, N> where N : NonVolatileMemory {
                               instruction: &'a [u8],
                               _: EnvId)
                               -> PassResult<'a> {
-        instruction_is!(instruction, HLC_OBSERVE);
+        InstructionIs(instruction, HLC_OBSERVE)?;
         if let Some(mut observed_bytes) = env.pop() {
             if let Ok(observed_time) = hlc::Timestamp::read_bytes(&mut observed_bytes) {
                 if self.timestamp.observe(&observed_time).is_err() {

--- a/pumpkindb_engine/src/script/mod_hlc.rs
+++ b/pumpkindb_engine/src/script/mod_hlc.rs
@@ -16,7 +16,7 @@ instruction!(HLC_TICK, b"\x88HLC/TICK");
 instruction!(HLC_OBSERVE, b"\x8BHLC/OBSERVE");
 
 use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
-            offset_by_size, InstructionIs, TryInstruction};
+            offset_by_size, TryInstruction};
 use timestamp;
 
 use hlc;
@@ -50,7 +50,7 @@ impl<'a, N> Handler<'a, N> where N : NonVolatileMemory {
 
     #[inline]
     pub fn handle_hlc(&self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        InstructionIs(instruction, HLC)?;
+        return_unless_instructions_equal!(instruction, HLC);
         let now = self.timestamp.hlc();
         let slice = alloc_slice!(16, env);
         let _ = now.write_bytes(&mut slice[0..]).unwrap();
@@ -64,7 +64,7 @@ impl<'a, N> Handler<'a, N> where N : NonVolatileMemory {
                            instruction: &'a [u8],
                            _: EnvId)
                            -> PassResult<'a> {
-        InstructionIs(instruction, HLC_TICK)?;
+        return_unless_instructions_equal!(instruction, HLC_TICK);
 
         let a = env.pop();
 
@@ -96,7 +96,7 @@ impl<'a, N> Handler<'a, N> where N : NonVolatileMemory {
                          instruction: &'a [u8],
                          _: EnvId)
                          -> PassResult<'a> {
-        InstructionIs(instruction, HLC_LC)?;
+        return_unless_instructions_equal!(instruction, HLC_LC);
         let a = env.pop();
 
         if a.is_none() {
@@ -127,7 +127,7 @@ impl<'a, N> Handler<'a, N> where N : NonVolatileMemory {
                               instruction: &'a [u8],
                               _: EnvId)
                               -> PassResult<'a> {
-        InstructionIs(instruction, HLC_OBSERVE)?;
+        return_unless_instructions_equal!(instruction, HLC_OBSERVE);
         if let Some(mut observed_bytes) = env.pop() {
             if let Ok(observed_time) = hlc::Timestamp::read_bytes(&mut observed_bytes) {
                 if self.timestamp.observe(&observed_time).is_err() {

--- a/pumpkindb_engine/src/script/mod_json.rs
+++ b/pumpkindb_engine/src/script/mod_json.rs
@@ -25,7 +25,7 @@ instruction!(JSON_STRING_TO, b"\x8dJSON/STRING->");
 instruction!(JSON_TO_STRING, b"\x8dJSON/->STRING");
 
 use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
-            offset_by_size, STACK_TRUE, STACK_FALSE, InstructionIs, TryInstruction};
+            offset_by_size, STACK_TRUE, STACK_FALSE, TryInstruction};
 use serde_json as json;
 
 use std::marker::PhantomData;
@@ -36,7 +36,7 @@ pub struct Handler<'a> {
 
 macro_rules! json_is_a {
     ($env: expr, $instruction: expr, $c: expr, { $t: ident }) => {{
-        InstructionIs($instruction, $c)?;
+        return_unless_instructions_equal!($instruction, $c);
         let a = stack_pop!($env);
 
         match json::from_slice::<json::Value>(a) {
@@ -47,7 +47,7 @@ macro_rules! json_is_a {
         Ok(())
     }};
     ($env: expr, $instruction: expr, $c: expr, $t: ident) => {{
-        InstructionIs($instruction, $c)?;
+        return_unless_instructions_equal!($instruction, $c);
         let a = stack_pop!($env);
 
         match json::from_slice::<json::Value>(a) {
@@ -93,7 +93,7 @@ impl<'a> Handler<'a> {
                         instruction: &'a [u8],
                         _: EnvId)
                         -> PassResult<'a> {
-        InstructionIs(instruction, JSONQ)?;
+        return_unless_instructions_equal!(instruction, JSONQ);
         let a = stack_pop!(env);
 
         match json::from_slice::<json::Value>(a) {
@@ -165,7 +165,7 @@ impl<'a> Handler<'a> {
                            instruction: &'a [u8],
                            _: EnvId)
                            -> PassResult<'a> {
-        InstructionIs(instruction, JSON_GET)?;
+        return_unless_instructions_equal!(instruction, JSON_GET);
 
         let field = stack_pop!(env);
         let a = stack_pop!(env);
@@ -199,7 +199,7 @@ impl<'a> Handler<'a> {
                             instruction: &'a [u8],
                             _: EnvId)
                             -> PassResult<'a> {
-        InstructionIs(instruction, JSON_HASQ)?;
+        return_unless_instructions_equal!(instruction, JSON_HASQ);
 
         let field = stack_pop!(env);
         let a = stack_pop!(env);
@@ -230,7 +230,7 @@ impl<'a> Handler<'a> {
                            instruction: &'a [u8],
                            _: EnvId)
                            -> PassResult<'a> {
-        InstructionIs(instruction, JSON_SET)?;
+        return_unless_instructions_equal!(instruction, JSON_SET);
 
         let value = stack_pop!(env);
         let field = stack_pop!(env);
@@ -266,7 +266,7 @@ impl<'a> Handler<'a> {
                                  instruction: &'a [u8],
                                  _: EnvId)
                                  -> PassResult<'a> {
-        InstructionIs(instruction, JSON_STRING_TO)?;
+        return_unless_instructions_equal!(instruction, JSON_STRING_TO);
 
         let a = stack_pop!(env);
 
@@ -288,7 +288,7 @@ impl<'a> Handler<'a> {
                                  instruction: &'a [u8],
                                  _: EnvId)
                                  -> PassResult<'a> {
-        InstructionIs(instruction, JSON_TO_STRING)?;
+        return_unless_instructions_equal!(instruction, JSON_TO_STRING);
 
         let a = stack_pop!(env);
 

--- a/pumpkindb_engine/src/script/mod_msg.rs
+++ b/pumpkindb_engine/src/script/mod_msg.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, offset_by_size,
-            InstructionIs, TryInstruction};
+            TryInstruction};
 use super::super::messaging;
 
 use std::marker::PhantomData;
@@ -44,7 +44,7 @@ impl<'a, P: messaging::Publisher, S: messaging::Subscriber> Handler<'a, P, S> {
                       instruction: &'a [u8],
                       _: EnvId)
                       -> PassResult<'a> {
-        InstructionIs(instruction, PUBLISH)?;
+        return_unless_instructions_equal!(instruction, PUBLISH);
         let topic = stack_pop!(env);
         let data = stack_pop!(env);
 
@@ -59,7 +59,7 @@ impl<'a, P: messaging::Publisher, S: messaging::Subscriber> Handler<'a, P, S> {
                       instruction: &'a [u8],
                       _: EnvId)
                       -> PassResult<'a> {
-        InstructionIs(instruction, SUBSCRIBE)?;
+        return_unless_instructions_equal!(instruction, SUBSCRIBE);
 
         let topic = stack_pop!(env);
 
@@ -81,7 +81,7 @@ impl<'a, P: messaging::Publisher, S: messaging::Subscriber> Handler<'a, P, S> {
                         instruction: &'a [u8],
                         _: EnvId)
                         -> PassResult<'a> {
-        InstructionIs(instruction, UNSUBSCRIBE)?;
+        return_unless_instructions_equal!(instruction, UNSUBSCRIBE);
 
         let identifier = stack_pop!(env);
 

--- a/pumpkindb_engine/src/script/mod_numbers.rs
+++ b/pumpkindb_engine/src/script/mod_numbers.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
-            offset_by_size, STACK_TRUE, STACK_FALSE, InstructionIs, TryInstruction};
+            offset_by_size, STACK_TRUE, STACK_FALSE, TryInstruction};
 
 use ::pumpkinscript::{Packable, Unpackable};
 
@@ -78,7 +78,7 @@ instruction!(F64_TO_STRING, b"\x8cF64/->STRING");
 
 macro_rules! uint_comparison {
     ($env: expr, $instruction: expr, $instruction_const: expr, $cmp: ident) => {{
-        InstructionIs($instruction, $instruction_const)?;
+        return_unless_instructions_equal!($instruction, $instruction_const);
         let b = stack_pop!($env);
         let a = stack_pop!($env);
 
@@ -96,7 +96,7 @@ macro_rules! uint_comparison {
 
 macro_rules! int_comparison {
     ($env: expr, $instruction: expr, $instruction_const: expr, $cmp: ident) => {{
-        InstructionIs($instruction, $instruction_const)?;
+        return_unless_instructions_equal!($instruction, $instruction_const);
         let b = stack_pop!($env);
         let a = stack_pop!($env);
 
@@ -325,7 +325,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, UINT_ADD)?;
+        return_unless_instructions_equal!(instruction, UINT_ADD);
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -344,7 +344,7 @@ impl<'a> Handler<'a> {
                       instruction: &'a [u8],
                       _: EnvId)
                       -> PassResult<'a> {
-        InstructionIs(instruction, INT_ADD)?;
+        return_unless_instructions_equal!(instruction, INT_ADD);
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -363,7 +363,7 @@ impl<'a> Handler<'a> {
                       instruction: &'a [u8],
                       _: EnvId)
                       -> PassResult<'a> {
-        InstructionIs(instruction, INT_SUB)?;
+        return_unless_instructions_equal!(instruction, INT_SUB);
         let b = stack_pop!(env);
         let a = stack_pop!(env);
 
@@ -382,7 +382,7 @@ impl<'a> Handler<'a> {
                           instruction: &'a [u8],
                           _: EnvId)
                           -> PassResult<'a> {
-        InstructionIs(instruction, INT_TO_UINT)?;
+        return_unless_instructions_equal!(instruction, INT_TO_UINT);
         let a = stack_pop!(env);
         let a_int : BigInt = a.unpack().ok_or(error_invalid_value!(a))?;
 
@@ -397,7 +397,7 @@ impl<'a> Handler<'a> {
                           instruction: &'a [u8],
                           _: EnvId)
                           -> PassResult<'a> {
-        InstructionIs(instruction, UINT_TO_INT)?;
+        return_unless_instructions_equal!(instruction, UINT_TO_INT);
         let a = stack_pop!(env);
         let a_uint = BigUint::from_bytes_be(a);
 
@@ -416,7 +416,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, UINT_SUB)?;
+        return_unless_instructions_equal!(instruction, UINT_SUB);
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -495,7 +495,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, UINT8_ADD)?;
+        return_unless_instructions_equal!(instruction, UINT8_ADD);
         no_endianness_sized_uint_op!(env, read_u8, checked_add, write_u8)
     }
 
@@ -505,7 +505,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, UINT8_SUB)?;
+        return_unless_instructions_equal!(instruction, UINT8_SUB);
         no_endianness_sized_uint_op!(env, read_u8, checked_sub, write_u8)
     }
 
@@ -515,7 +515,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, INT8_ADD)?;
+        return_unless_instructions_equal!(instruction, INT8_ADD);
         no_endianness_sized_int_op!(env, read_i8, checked_add, write_i8)
     }
 
@@ -525,7 +525,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, INT8_SUB)?;
+        return_unless_instructions_equal!(instruction, INT8_SUB);
         no_endianness_sized_int_op!(env, read_i8, checked_sub, write_i8)
     }
 
@@ -535,7 +535,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, UINT16_ADD)?;
+        return_unless_instructions_equal!(instruction, UINT16_ADD);
         sized_uint_op!(env, read_u16, checked_add, write_u16)
     }
 
@@ -545,7 +545,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, UINT16_SUB)?;
+        return_unless_instructions_equal!(instruction, UINT16_SUB);
         sized_uint_op!(env, read_u16, checked_sub, write_u16)
     }
 
@@ -555,7 +555,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, INT16_ADD)?;
+        return_unless_instructions_equal!(instruction, INT16_ADD);
         sized_int_op!(env, read_i16, checked_add, write_i16)
     }
 
@@ -565,7 +565,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, INT16_SUB)?;
+        return_unless_instructions_equal!(instruction, INT16_SUB);
         sized_int_op!(env, read_i16, checked_sub, write_i16)
     }
 
@@ -575,7 +575,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, UINT32_ADD)?;
+        return_unless_instructions_equal!(instruction, UINT32_ADD);
         sized_uint_op!(env, read_u32, checked_add, write_u32)
     }
 
@@ -585,7 +585,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, UINT32_SUB)?;
+        return_unless_instructions_equal!(instruction, UINT32_SUB);
         sized_uint_op!(env, read_u32, checked_sub, write_u32)
     }
 
@@ -595,7 +595,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, INT32_ADD)?;
+        return_unless_instructions_equal!(instruction, INT32_ADD);
         sized_int_op!(env, read_i32, checked_add, write_i32)
     }
 
@@ -605,7 +605,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, INT32_SUB)?;
+        return_unless_instructions_equal!(instruction, INT32_SUB);
         sized_int_op!(env, read_i32, checked_sub, write_i32)
     }
 
@@ -615,7 +615,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, UINT64_ADD)?;
+        return_unless_instructions_equal!(instruction, UINT64_ADD);
         sized_uint_op!(env, read_u64, checked_add, write_u64)
     }
 
@@ -625,7 +625,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, UINT64_SUB)?;
+        return_unless_instructions_equal!(instruction, UINT64_SUB);
         sized_uint_op!(env, read_u64, checked_sub, write_u64)
     }
 
@@ -635,7 +635,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, INT64_ADD)?;
+        return_unless_instructions_equal!(instruction, INT64_ADD);
         sized_int_op!(env, read_i64, checked_add, write_i64)
     }
 
@@ -645,7 +645,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, INT64_SUB)?;
+        return_unless_instructions_equal!(instruction, INT64_SUB);
         sized_int_op!(env, read_i64, checked_sub, write_i64)
     }
     
@@ -655,7 +655,7 @@ impl<'a> Handler<'a> {
                         instruction: &'a [u8],
                         _: EnvId)
                         -> PassResult<'a> {
-        InstructionIs(instruction, F32_ADD)?;
+        return_unless_instructions_equal!(instruction, F32_ADD);
         let a_bytes = stack_pop!(env);
         let a: f32 = a_bytes.unpack().ok_or(error_invalid_value!(a_bytes))?;
             
@@ -675,7 +675,7 @@ impl<'a> Handler<'a> {
                       instruction: &'a [u8],
                       _: EnvId)
                       -> PassResult<'a> {
-        InstructionIs(instruction, F32_SUB)?;
+        return_unless_instructions_equal!(instruction, F32_SUB);
         let a_bytes = stack_pop!(env);
         let a: f32 = a_bytes.unpack().ok_or(error_invalid_value!(a_bytes))?;
         
@@ -695,7 +695,7 @@ impl<'a> Handler<'a> {
                         instruction: &'a [u8],
                         _: EnvId)
                         -> PassResult<'a> {
-        InstructionIs(instruction, F64_ADD)?;
+        return_unless_instructions_equal!(instruction, F64_ADD);
         let a_bytes = stack_pop!(env);
         let a: f64 = a_bytes.unpack().ok_or(error_invalid_value!(a_bytes))?;
         
@@ -715,7 +715,7 @@ impl<'a> Handler<'a> {
                       instruction: &'a [u8],
                       _: EnvId)
                       -> PassResult<'a> {
-        InstructionIs(instruction, F64_SUB)?;
+        return_unless_instructions_equal!(instruction, F64_SUB);
         let a_bytes = stack_pop!(env);
         let a: f64 = a_bytes.unpack().ok_or(error_invalid_value!(a_bytes))?;
         
@@ -735,7 +735,7 @@ impl<'a> Handler<'a> {
                         instruction: &'a [u8],
                         _: EnvId)
                         -> PassResult<'a> {
-        InstructionIs(instruction, UINT_TO_STRING)?;
+        return_unless_instructions_equal!(instruction, UINT_TO_STRING);
 
         let a_bytes = stack_pop!(env);
         let a: BigUint = a_bytes.unpack().ok_or(error_invalid_value!(a_bytes))?;
@@ -753,7 +753,7 @@ impl<'a> Handler<'a> {
                              instruction: &'a [u8],
                              _: EnvId)
                              -> PassResult<'a> {
-        InstructionIs(instruction, INT_TO_STRING)?;
+        return_unless_instructions_equal!(instruction, INT_TO_STRING);
         
         let a_bytes = stack_pop!(env);
         let a: BigInt = a_bytes.unpack().ok_or(error_invalid_value!(a_bytes))?;

--- a/pumpkindb_engine/src/script/mod_numbers.rs
+++ b/pumpkindb_engine/src/script/mod_numbers.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
-            offset_by_size, STACK_TRUE, STACK_FALSE};
+            offset_by_size, STACK_TRUE, STACK_FALSE, InstructionIs, TryInstruction};
 
 use ::pumpkinscript::{Packable, Unpackable};
 
@@ -78,7 +78,7 @@ instruction!(F64_TO_STRING, b"\x8cF64/->STRING");
 
 macro_rules! uint_comparison {
     ($env: expr, $instruction: expr, $instruction_const: expr, $cmp: ident) => {{
-        instruction_is!($instruction, $instruction_const);
+        InstructionIs($instruction, $instruction_const)?;
         let b = stack_pop!($env);
         let a = stack_pop!($env);
 
@@ -96,7 +96,7 @@ macro_rules! uint_comparison {
 
 macro_rules! int_comparison {
     ($env: expr, $instruction: expr, $instruction_const: expr, $cmp: ident) => {{
-        instruction_is!($instruction, $instruction_const);
+        InstructionIs($instruction, $instruction_const)?;
         let b = stack_pop!($env);
         let a = stack_pop!($env);
 
@@ -273,43 +273,43 @@ pub struct Handler<'a> {
 
 impl<'a> Dispatcher<'a> for Handler<'a> {
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
-        try_instruction!(env, self.handle_uint_add(env, instruction, pid));
-        try_instruction!(env, self.handle_uint_sub(env, instruction, pid));
-        try_instruction!(env, self.handle_int_add(env, instruction, pid));
-        try_instruction!(env, self.handle_int_sub(env, instruction, pid));
-        try_instruction!(env, self.handle_int_to_uint(env, instruction, pid));
-        try_instruction!(env, self.handle_uint_to_int(env, instruction, pid));
-        try_instruction!(env, self.handle_uint_equalq(env, instruction, pid));
-        try_instruction!(env, self.handle_uint_gtq(env, instruction, pid));
-        try_instruction!(env, self.handle_uint_ltq(env, instruction, pid));
-        try_instruction!(env, self.handle_int_equalq(env, instruction, pid));
-        try_instruction!(env, self.handle_int_gtq(env, instruction, pid));
-        try_instruction!(env, self.handle_int_ltq(env, instruction, pid));
-        try_instruction!(env, self.handle_uint8_add(env, instruction, pid));
-        try_instruction!(env, self.handle_uint8_sub(env, instruction, pid));
-        try_instruction!(env, self.handle_int8_add(env, instruction, pid));
-        try_instruction!(env, self.handle_int8_sub(env, instruction, pid));
-        try_instruction!(env, self.handle_uint16_add(env, instruction, pid));
-        try_instruction!(env, self.handle_uint16_sub(env, instruction, pid));
-        try_instruction!(env, self.handle_int16_add(env, instruction, pid));
-        try_instruction!(env, self.handle_int16_sub(env, instruction, pid));
-        try_instruction!(env, self.handle_uint32_add(env, instruction, pid));
-        try_instruction!(env, self.handle_uint32_sub(env, instruction, pid));
-        try_instruction!(env, self.handle_int32_add(env, instruction, pid));
-        try_instruction!(env, self.handle_int32_sub(env, instruction, pid));
-        try_instruction!(env, self.handle_uint64_add(env, instruction, pid));
-        try_instruction!(env, self.handle_uint64_sub(env, instruction, pid));
-        try_instruction!(env, self.handle_int64_add(env, instruction, pid));
-        try_instruction!(env, self.handle_int64_sub(env, instruction, pid));
-        try_instruction!(env, self.handle_f32_add(env, instruction, pid));
-        try_instruction!(env, self.handle_f32_sub(env, instruction, pid));
-        try_instruction!(env, self.handle_f64_add(env, instruction, pid));
-        try_instruction!(env, self.handle_f64_sub(env, instruction, pid));
+        self.handle_uint_add(env, instruction, pid)
+        .if_unhandled_try(|| self.handle_uint_sub(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int_add(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int_sub(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int_to_uint(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_uint_to_int(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_uint_equalq(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_uint_gtq(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_uint_ltq(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int_equalq(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int_gtq(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int_ltq(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_uint8_add(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_uint8_sub(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int8_add(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int8_sub(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_uint16_add(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_uint16_sub(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int16_add(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int16_sub(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_uint32_add(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_uint32_sub(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int32_add(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int32_sub(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_uint64_add(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_uint64_sub(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int64_add(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int64_sub(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_f32_add(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_f32_sub(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_f64_add(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_f64_sub(env, instruction, pid))
 
-        try_instruction!(env, self.handle_uint_to_string(env, instruction, pid));
-        try_instruction!(env, self.handle_int_to_string(env, instruction, pid));
-        try_instruction!(env, self.handle_to_string(env, instruction, pid));
-        Err(Error::UnknownInstruction)
+        .if_unhandled_try(|| self.handle_uint_to_string(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_int_to_string(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_to_string(env, instruction, pid))
+        .if_unhandled_try(|| Err(Error::UnknownInstruction))
     }
 }
 
@@ -325,7 +325,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, UINT_ADD);
+        InstructionIs(instruction, UINT_ADD)?;
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -344,7 +344,7 @@ impl<'a> Handler<'a> {
                       instruction: &'a [u8],
                       _: EnvId)
                       -> PassResult<'a> {
-        instruction_is!(instruction, INT_ADD);
+        InstructionIs(instruction, INT_ADD)?;
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -363,7 +363,7 @@ impl<'a> Handler<'a> {
                       instruction: &'a [u8],
                       _: EnvId)
                       -> PassResult<'a> {
-        instruction_is!(instruction, INT_SUB);
+        InstructionIs(instruction, INT_SUB)?;
         let b = stack_pop!(env);
         let a = stack_pop!(env);
 
@@ -382,7 +382,7 @@ impl<'a> Handler<'a> {
                           instruction: &'a [u8],
                           _: EnvId)
                           -> PassResult<'a> {
-        instruction_is!(instruction, INT_TO_UINT);
+        InstructionIs(instruction, INT_TO_UINT)?;
         let a = stack_pop!(env);
         let a_int : BigInt = a.unpack().ok_or(error_invalid_value!(a))?;
 
@@ -397,7 +397,7 @@ impl<'a> Handler<'a> {
                           instruction: &'a [u8],
                           _: EnvId)
                           -> PassResult<'a> {
-        instruction_is!(instruction, UINT_TO_INT);
+        InstructionIs(instruction, UINT_TO_INT)?;
         let a = stack_pop!(env);
         let a_uint = BigUint::from_bytes_be(a);
 
@@ -416,7 +416,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, UINT_SUB);
+        InstructionIs(instruction, UINT_SUB)?;
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -495,7 +495,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, UINT8_ADD);
+        InstructionIs(instruction, UINT8_ADD)?;
         no_endianness_sized_uint_op!(env, read_u8, checked_add, write_u8)
     }
 
@@ -505,7 +505,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, UINT8_SUB);
+        InstructionIs(instruction, UINT8_SUB)?;
         no_endianness_sized_uint_op!(env, read_u8, checked_sub, write_u8)
     }
 
@@ -515,7 +515,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, INT8_ADD);
+        InstructionIs(instruction, INT8_ADD)?;
         no_endianness_sized_int_op!(env, read_i8, checked_add, write_i8)
     }
 
@@ -525,7 +525,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, INT8_SUB);
+        InstructionIs(instruction, INT8_SUB)?;
         no_endianness_sized_int_op!(env, read_i8, checked_sub, write_i8)
     }
 
@@ -535,7 +535,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, UINT16_ADD);
+        InstructionIs(instruction, UINT16_ADD)?;
         sized_uint_op!(env, read_u16, checked_add, write_u16)
     }
 
@@ -545,7 +545,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, UINT16_SUB);
+        InstructionIs(instruction, UINT16_SUB)?;
         sized_uint_op!(env, read_u16, checked_sub, write_u16)
     }
 
@@ -555,7 +555,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, INT16_ADD);
+        InstructionIs(instruction, INT16_ADD)?;
         sized_int_op!(env, read_i16, checked_add, write_i16)
     }
 
@@ -565,7 +565,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, INT16_SUB);
+        InstructionIs(instruction, INT16_SUB)?;
         sized_int_op!(env, read_i16, checked_sub, write_i16)
     }
 
@@ -575,7 +575,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, UINT32_ADD);
+        InstructionIs(instruction, UINT32_ADD)?;
         sized_uint_op!(env, read_u32, checked_add, write_u32)
     }
 
@@ -585,7 +585,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, UINT32_SUB);
+        InstructionIs(instruction, UINT32_SUB)?;
         sized_uint_op!(env, read_u32, checked_sub, write_u32)
     }
 
@@ -595,7 +595,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, INT32_ADD);
+        InstructionIs(instruction, INT32_ADD)?;
         sized_int_op!(env, read_i32, checked_add, write_i32)
     }
 
@@ -605,7 +605,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, INT32_SUB);
+        InstructionIs(instruction, INT32_SUB)?;
         sized_int_op!(env, read_i32, checked_sub, write_i32)
     }
 
@@ -615,7 +615,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, UINT64_ADD);
+        InstructionIs(instruction, UINT64_ADD)?;
         sized_uint_op!(env, read_u64, checked_add, write_u64)
     }
 
@@ -625,7 +625,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, UINT64_SUB);
+        InstructionIs(instruction, UINT64_SUB)?;
         sized_uint_op!(env, read_u64, checked_sub, write_u64)
     }
 
@@ -635,7 +635,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, INT64_ADD);
+        InstructionIs(instruction, INT64_ADD)?;
         sized_int_op!(env, read_i64, checked_add, write_i64)
     }
 
@@ -645,7 +645,7 @@ impl<'a> Handler<'a> {
                        instruction: &'a [u8],
                        _: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, INT64_SUB);
+        InstructionIs(instruction, INT64_SUB)?;
         sized_int_op!(env, read_i64, checked_sub, write_i64)
     }
     
@@ -655,7 +655,7 @@ impl<'a> Handler<'a> {
                         instruction: &'a [u8],
                         _: EnvId)
                         -> PassResult<'a> {
-        instruction_is!(instruction, F32_ADD);
+        InstructionIs(instruction, F32_ADD)?;
         let a_bytes = stack_pop!(env);
         let a: f32 = a_bytes.unpack().ok_or(error_invalid_value!(a_bytes))?;
             
@@ -675,7 +675,7 @@ impl<'a> Handler<'a> {
                       instruction: &'a [u8],
                       _: EnvId)
                       -> PassResult<'a> {
-        instruction_is!(instruction, F32_SUB);
+        InstructionIs(instruction, F32_SUB)?;
         let a_bytes = stack_pop!(env);
         let a: f32 = a_bytes.unpack().ok_or(error_invalid_value!(a_bytes))?;
         
@@ -695,7 +695,7 @@ impl<'a> Handler<'a> {
                         instruction: &'a [u8],
                         _: EnvId)
                         -> PassResult<'a> {
-        instruction_is!(instruction, F64_ADD);
+        InstructionIs(instruction, F64_ADD)?;
         let a_bytes = stack_pop!(env);
         let a: f64 = a_bytes.unpack().ok_or(error_invalid_value!(a_bytes))?;
         
@@ -715,7 +715,7 @@ impl<'a> Handler<'a> {
                       instruction: &'a [u8],
                       _: EnvId)
                       -> PassResult<'a> {
-        instruction_is!(instruction, F64_SUB);
+        InstructionIs(instruction, F64_SUB)?;
         let a_bytes = stack_pop!(env);
         let a: f64 = a_bytes.unpack().ok_or(error_invalid_value!(a_bytes))?;
         
@@ -735,7 +735,7 @@ impl<'a> Handler<'a> {
                         instruction: &'a [u8],
                         _: EnvId)
                         -> PassResult<'a> {
-        instruction_is!(instruction, UINT_TO_STRING);
+        InstructionIs(instruction, UINT_TO_STRING)?;
 
         let a_bytes = stack_pop!(env);
         let a: BigUint = a_bytes.unpack().ok_or(error_invalid_value!(a_bytes))?;
@@ -753,7 +753,7 @@ impl<'a> Handler<'a> {
                              instruction: &'a [u8],
                              _: EnvId)
                              -> PassResult<'a> {
-        instruction_is!(instruction, INT_TO_STRING);
+        InstructionIs(instruction, INT_TO_STRING)?;
         
         let a_bytes = stack_pop!(env);
         let a: BigInt = a_bytes.unpack().ok_or(error_invalid_value!(a_bytes))?;

--- a/pumpkindb_engine/src/script/mod_stack.rs
+++ b/pumpkindb_engine/src/script/mod_stack.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use pumpkinscript::{offset_by_size, binparser};
-use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE, InstructionIs, TryInstruction};
+use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE, TryInstruction};
 
 use std::marker::PhantomData;
 
@@ -58,7 +58,7 @@ impl<'a> Handler<'a> {
 
     #[inline]
     fn handle_dup(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        InstructionIs(instruction, DUP)?;
+        return_unless_instructions_equal!(instruction, DUP);
         let v = stack_pop!(env);
 
         env.push(v);
@@ -72,7 +72,7 @@ impl<'a> Handler<'a> {
                    instruction: &'a [u8],
                    _: EnvId)
                    -> PassResult<'a> {
-        InstructionIs(instruction, SWAP)?;
+        return_unless_instructions_equal!(instruction, SWAP);
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -88,7 +88,7 @@ impl<'a> Handler<'a> {
                     instruction: &'a [u8],
                     _: EnvId)
                     -> PassResult<'a> {
-        InstructionIs(instruction, TWOSWAP)?;
+        return_unless_instructions_equal!(instruction, TWOSWAP);
         let a = stack_pop!(env);
         let b = stack_pop!(env);
         let c = stack_pop!(env);
@@ -109,7 +109,7 @@ impl<'a> Handler<'a> {
                    instruction: &'a [u8],
                    _: EnvId)
                    -> PassResult<'a> {
-        InstructionIs(instruction, OVER)?;
+        return_unless_instructions_equal!(instruction, OVER);
         let a = stack_pop!(env);
         let b = stack_pop!(env);
 
@@ -126,7 +126,7 @@ impl<'a> Handler<'a> {
                     instruction: &'a [u8],
                     _: EnvId)
                     -> PassResult<'a> {
-        InstructionIs(instruction, TWOOVER)?;
+        return_unless_instructions_equal!(instruction, TWOOVER);
         let d = stack_pop!(env);
         let c = stack_pop!(env);
         let b = stack_pop!(env);
@@ -144,7 +144,7 @@ impl<'a> Handler<'a> {
 
     #[inline]
     fn handle_rot(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
-        InstructionIs(instruction, ROT)?;
+        return_unless_instructions_equal!(instruction, ROT);
         let a = stack_pop!(env);
         let b = stack_pop!(env);
         let c = stack_pop!(env);
@@ -162,7 +162,7 @@ impl<'a> Handler<'a> {
                    instruction: &'a [u8],
                    _: EnvId)
                    -> PassResult<'a> {
-        InstructionIs(instruction, TWOROT)?;
+        return_unless_instructions_equal!(instruction, TWOROT);
         let f = stack_pop!(env);
         let e = stack_pop!(env);
         let d = stack_pop!(env);
@@ -186,7 +186,7 @@ impl<'a> Handler<'a> {
                    instruction: &'a [u8],
                    _: EnvId)
                    -> PassResult<'a> {
-        InstructionIs(instruction, DROP)?;
+        return_unless_instructions_equal!(instruction, DROP);
         let _ = stack_pop!(env);
 
         Ok(())
@@ -198,7 +198,7 @@ impl<'a> Handler<'a> {
                     instruction: &'a [u8],
                     _: EnvId)
                     -> PassResult<'a> {
-        InstructionIs(instruction, DEPTH)?;
+        return_unless_instructions_equal!(instruction, DEPTH);
         let bytes = BigUint::from(env.stack_size).to_bytes_be();
         let slice = alloc_and_write!(bytes.as_slice(), env);
         env.push(slice);
@@ -211,7 +211,7 @@ impl<'a> Handler<'a> {
                    instruction: &'a [u8],
                    _: EnvId)
                    -> PassResult<'a> {
-        InstructionIs(instruction, WRAP)?;
+        return_unless_instructions_equal!(instruction, WRAP);
         let n = stack_pop!(env);
 
         let mut n_int = BigUint::from_bytes_be(n).to_u64().unwrap() as usize;
@@ -247,7 +247,7 @@ impl<'a> Handler<'a> {
                      instruction: &'a [u8],
                      _: EnvId)
                      -> PassResult<'a> {
-        InstructionIs(instruction, UNWRAP)?;
+        return_unless_instructions_equal!(instruction, UNWRAP);
         let mut current = stack_pop!(env);
         while current.len() > 0 {
             match binparser::data(current) {

--- a/pumpkindb_engine/src/script/mod_storage.rs
+++ b/pumpkindb_engine/src/script/mod_storage.rs
@@ -18,7 +18,7 @@ use std::error::Error as StdError;
 use std::collections::HashMap;
 use super::{Env, EnvId, Dispatcher, PassResult, Error, STACK_TRUE, STACK_FALSE, offset_by_size,
             ERROR_EMPTY_STACK, ERROR_INVALID_VALUE, ERROR_DUPLICATE_KEY, ERROR_NO_TX,
-            ERROR_UNKNOWN_KEY, ERROR_DATABASE, ERROR_NO_VALUE};
+            ERROR_UNKNOWN_KEY, ERROR_DATABASE, ERROR_NO_VALUE, InstructionIs, TryInstruction};
 use snowflake::ProcessUniqueId;
 use std::collections::BTreeMap;
 use storage::WriteTransactionContainer;
@@ -207,25 +207,25 @@ impl<'a, T, N> Dispatcher<'a> for Handler<'a, T, N>
     }
 
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
-        try_instruction!(env, self.handle_builtins(env, instruction, pid));
-        try_instruction!(env, self.handle_write(env, instruction, pid));
-        try_instruction!(env, self.handle_read(env, instruction, pid));
-        try_instruction!(env, self.handle_txid(env, instruction, pid));
-        try_instruction!(env, self.handle_assoc(env, instruction, pid));
-        try_instruction!(env, self.handle_assocq(env, instruction, pid));
-        try_instruction!(env, self.handle_retr(env, instruction, pid));
-        try_instruction!(env, self.handle_commit(env, instruction, pid));
-        try_instruction!(env, self.handle_cursor(env, instruction, pid));
-        try_instruction!(env, self.handle_cursor_first(env, instruction, pid));
-        try_instruction!(env, self.handle_cursor_next(env, instruction, pid));
-        try_instruction!(env, self.handle_cursor_prev(env, instruction, pid));
-        try_instruction!(env, self.handle_cursor_last(env, instruction, pid));
-        try_instruction!(env, self.handle_cursor_seek(env, instruction, pid));
-        try_instruction!(env, self.handle_cursor_positionedq(env, instruction, pid));
-        try_instruction!(env, self.handle_cursor_key(env, instruction, pid));
-        try_instruction!(env, self.handle_cursor_val(env, instruction, pid));
-        try_instruction!(env, self.handle_maxkeysize(env, instruction, pid));
-        Err(Error::UnknownInstruction)
+        self.handle_builtins(env, instruction, pid)
+        .if_unhandled_try(|| self.handle_write(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_read(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_txid(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_assoc(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_assocq(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_retr(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_commit(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_cursor(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_cursor_first(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_cursor_next(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_cursor_prev(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_cursor_last(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_cursor_seek(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_cursor_positionedq(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_cursor_key(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_cursor_val(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_maxkeysize(env, instruction, pid))
+        .if_unhandled_try(|| Err(Error::UnknownInstruction))
     }
 }
 
@@ -353,7 +353,7 @@ impl<'a, T, N> Handler<'a, T, N>
                        instruction: &'a [u8],
                        pid: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, TXID);
+        InstructionIs(instruction, TXID)?;
         self.txns.get(&pid)
             .and_then(|v| Some(&v[v.len() - 1]))
             .and_then(|txn| Some(txn.id()))
@@ -369,7 +369,7 @@ impl<'a, T, N> Handler<'a, T, N>
 						instruction: &'a [u8],
 						pid: EnvId)
 						-> PassResult<'a> {
-        instruction_is!(instruction, ASSOC);
+        InstructionIs(instruction, ASSOC)?;
         match self.txns.get(&pid)
             .and_then(|v| Some(&v[v.len() - 1]))
             .and_then(|txn| match txn.tx_type() {
@@ -398,7 +398,7 @@ impl<'a, T, N> Handler<'a, T, N>
 						 instruction: &'a [u8],
 						 pid: EnvId)
 						 -> PassResult<'a> {
-        instruction_is!(instruction, COMMIT);
+        InstructionIs(instruction, COMMIT)?;
         match self.txns.get_mut(&pid)
             .and_then(|vec| vec.pop()) {
             Some(Txn::Write(txn, _)) => {
@@ -422,7 +422,7 @@ impl<'a, T, N> Handler<'a, T, N>
                        instruction: &'a [u8],
                        pid: EnvId)
                        -> PassResult<'a> {
-        instruction_is!(instruction, RETR);
+        InstructionIs(instruction, RETR)?;
         let key = stack_pop!(env);
         self.txns.get(&pid)
             .and_then(|v| Some(&v[v.len() - 1]))
@@ -446,7 +446,7 @@ impl<'a, T, N> Handler<'a, T, N>
                          instruction: &'a [u8],
                          pid: EnvId)
                          -> PassResult<'a> {
-        instruction_is!(instruction, ASSOCQ);
+        InstructionIs(instruction, ASSOCQ)?;
         let key = stack_pop!(env);
         self.txns.get(&pid)
             .and_then(|v| Some(&v[v.len() - 1]))
@@ -477,7 +477,7 @@ impl<'a, T, N> Handler<'a, T, N>
 						 pid: EnvId)
 						 -> PassResult<'a> {
         use serde_cbor;
-        instruction_is!(instruction, CURSOR);
+        InstructionIs(instruction, CURSOR)?;
         let db = self.db.as_ref();
         let cursor = self.txns.get(&pid)
             .and_then(|v| Some(&v[v.len() - 1]))
@@ -508,7 +508,7 @@ impl<'a, T, N> Handler<'a, T, N>
                                instruction: &'a [u8],
                                pid: EnvId)
                                -> PassResult<'a> {
-        instruction_is!(instruction, CURSOR_FIRST);
+        InstructionIs(instruction, CURSOR_FIRST)?;
         cursor_op!(self, env, pid, first, ());
         Ok(())
     }
@@ -520,7 +520,7 @@ impl<'a, T, N> Handler<'a, T, N>
                               instruction: &'a [u8],
                               pid: EnvId)
                               -> PassResult<'a> {
-        instruction_is!(instruction, CURSOR_NEXT);
+        InstructionIs(instruction, CURSOR_NEXT)?;
         cursor_op!(self, env, pid, next, ());
         Ok(())
     }
@@ -531,7 +531,7 @@ impl<'a, T, N> Handler<'a, T, N>
                               instruction: &'a [u8],
                               pid: EnvId)
                               -> PassResult<'a> {
-        instruction_is!(instruction, CURSOR_PREV);
+        InstructionIs(instruction, CURSOR_PREV)?;
         cursor_op!(self, env, pid, prev, ());
         Ok(())
     }
@@ -542,7 +542,7 @@ impl<'a, T, N> Handler<'a, T, N>
                               instruction: &'a [u8],
                               pid: EnvId)
                               -> PassResult<'a> {
-        instruction_is!(instruction, CURSOR_LAST);
+        InstructionIs(instruction, CURSOR_LAST)?;
         cursor_op!(self, env, pid, last, ());
         Ok(())
     }
@@ -553,7 +553,7 @@ impl<'a, T, N> Handler<'a, T, N>
                               instruction: &'a [u8],
                               pid: EnvId)
                               -> PassResult<'a> {
-        instruction_is!(instruction, CURSOR_SEEK);
+        InstructionIs(instruction, CURSOR_SEEK)?;
         let key = stack_pop!(env);
         cursor_op!(self, env, pid, seek_range_k, (key));
         Ok(())
@@ -565,7 +565,7 @@ impl<'a, T, N> Handler<'a, T, N>
                               instruction: &'a [u8],
                               pid: EnvId)
                               -> PassResult<'a> {
-        instruction_is!(instruction, CURSOR_POSITIONEDQ);
+        InstructionIs(instruction, CURSOR_POSITIONEDQ)?;
         let result = match cursor_map_op!(self, env, pid, get_current, (), |_| Ok(true), |_| false) {
             Ok(true) => STACK_TRUE,
             Err(false) => STACK_FALSE,
@@ -581,7 +581,7 @@ impl<'a, T, N> Handler<'a, T, N>
                              instruction: &'a [u8],
                              pid: EnvId)
                              -> PassResult<'a> {
-        instruction_is!(instruction, CURSOR_KEY);
+        InstructionIs(instruction, CURSOR_KEY)?;
         cursor_map_op!(self, env, pid, get_current, (),
            |(key, _) | {
               let slice = alloc_slice!(key.len(), env);
@@ -597,7 +597,7 @@ impl<'a, T, N> Handler<'a, T, N>
                              instruction: &'a [u8],
                              pid: EnvId)
                              -> PassResult<'a> {
-        instruction_is!(instruction, CURSOR_VAL);
+        InstructionIs(instruction, CURSOR_VAL)?;
         cursor_map_op!(self, env, pid, get_current, (),
            |(_, val) | {
               let slice = alloc_slice!(val.len(), env);
@@ -613,7 +613,7 @@ impl<'a, T, N> Handler<'a, T, N>
                              instruction: &'a [u8],
                              _: EnvId)
                              -> PassResult<'a> {
-        instruction_is!(instruction, MAXKEYSIZE);
+        InstructionIs(instruction, MAXKEYSIZE)?;
         let slice = alloc_and_write!(self.maxkeysize.as_slice(), env);
         env.push(slice);
         Ok(())

--- a/pumpkindb_engine/src/script/mod_storage.rs
+++ b/pumpkindb_engine/src/script/mod_storage.rs
@@ -18,7 +18,7 @@ use std::error::Error as StdError;
 use std::collections::HashMap;
 use super::{Env, EnvId, Dispatcher, PassResult, Error, STACK_TRUE, STACK_FALSE, offset_by_size,
             ERROR_EMPTY_STACK, ERROR_INVALID_VALUE, ERROR_DUPLICATE_KEY, ERROR_NO_TX,
-            ERROR_UNKNOWN_KEY, ERROR_DATABASE, ERROR_NO_VALUE, InstructionIs, TryInstruction};
+            ERROR_UNKNOWN_KEY, ERROR_DATABASE, ERROR_NO_VALUE, TryInstruction};
 use snowflake::ProcessUniqueId;
 use std::collections::BTreeMap;
 use storage::WriteTransactionContainer;
@@ -353,7 +353,7 @@ impl<'a, T, N> Handler<'a, T, N>
                        instruction: &'a [u8],
                        pid: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, TXID)?;
+        return_unless_instructions_equal!(instruction, TXID);
         self.txns.get(&pid)
             .and_then(|v| Some(&v[v.len() - 1]))
             .and_then(|txn| Some(txn.id()))
@@ -369,7 +369,7 @@ impl<'a, T, N> Handler<'a, T, N>
 						instruction: &'a [u8],
 						pid: EnvId)
 						-> PassResult<'a> {
-        InstructionIs(instruction, ASSOC)?;
+        return_unless_instructions_equal!(instruction, ASSOC);
         match self.txns.get(&pid)
             .and_then(|v| Some(&v[v.len() - 1]))
             .and_then(|txn| match txn.tx_type() {
@@ -398,7 +398,7 @@ impl<'a, T, N> Handler<'a, T, N>
 						 instruction: &'a [u8],
 						 pid: EnvId)
 						 -> PassResult<'a> {
-        InstructionIs(instruction, COMMIT)?;
+        return_unless_instructions_equal!(instruction, COMMIT);
         match self.txns.get_mut(&pid)
             .and_then(|vec| vec.pop()) {
             Some(Txn::Write(txn, _)) => {
@@ -422,7 +422,7 @@ impl<'a, T, N> Handler<'a, T, N>
                        instruction: &'a [u8],
                        pid: EnvId)
                        -> PassResult<'a> {
-        InstructionIs(instruction, RETR)?;
+        return_unless_instructions_equal!(instruction, RETR);
         let key = stack_pop!(env);
         self.txns.get(&pid)
             .and_then(|v| Some(&v[v.len() - 1]))
@@ -446,7 +446,7 @@ impl<'a, T, N> Handler<'a, T, N>
                          instruction: &'a [u8],
                          pid: EnvId)
                          -> PassResult<'a> {
-        InstructionIs(instruction, ASSOCQ)?;
+        return_unless_instructions_equal!(instruction, ASSOCQ);
         let key = stack_pop!(env);
         self.txns.get(&pid)
             .and_then(|v| Some(&v[v.len() - 1]))
@@ -477,7 +477,7 @@ impl<'a, T, N> Handler<'a, T, N>
 						 pid: EnvId)
 						 -> PassResult<'a> {
         use serde_cbor;
-        InstructionIs(instruction, CURSOR)?;
+        return_unless_instructions_equal!(instruction, CURSOR);
         let db = self.db.as_ref();
         let cursor = self.txns.get(&pid)
             .and_then(|v| Some(&v[v.len() - 1]))
@@ -508,7 +508,7 @@ impl<'a, T, N> Handler<'a, T, N>
                                instruction: &'a [u8],
                                pid: EnvId)
                                -> PassResult<'a> {
-        InstructionIs(instruction, CURSOR_FIRST)?;
+        return_unless_instructions_equal!(instruction, CURSOR_FIRST);
         cursor_op!(self, env, pid, first, ());
         Ok(())
     }
@@ -520,7 +520,7 @@ impl<'a, T, N> Handler<'a, T, N>
                               instruction: &'a [u8],
                               pid: EnvId)
                               -> PassResult<'a> {
-        InstructionIs(instruction, CURSOR_NEXT)?;
+        return_unless_instructions_equal!(instruction, CURSOR_NEXT);
         cursor_op!(self, env, pid, next, ());
         Ok(())
     }
@@ -531,7 +531,7 @@ impl<'a, T, N> Handler<'a, T, N>
                               instruction: &'a [u8],
                               pid: EnvId)
                               -> PassResult<'a> {
-        InstructionIs(instruction, CURSOR_PREV)?;
+        return_unless_instructions_equal!(instruction, CURSOR_PREV);
         cursor_op!(self, env, pid, prev, ());
         Ok(())
     }
@@ -542,7 +542,7 @@ impl<'a, T, N> Handler<'a, T, N>
                               instruction: &'a [u8],
                               pid: EnvId)
                               -> PassResult<'a> {
-        InstructionIs(instruction, CURSOR_LAST)?;
+        return_unless_instructions_equal!(instruction, CURSOR_LAST);
         cursor_op!(self, env, pid, last, ());
         Ok(())
     }
@@ -553,7 +553,7 @@ impl<'a, T, N> Handler<'a, T, N>
                               instruction: &'a [u8],
                               pid: EnvId)
                               -> PassResult<'a> {
-        InstructionIs(instruction, CURSOR_SEEK)?;
+        return_unless_instructions_equal!(instruction, CURSOR_SEEK);
         let key = stack_pop!(env);
         cursor_op!(self, env, pid, seek_range_k, (key));
         Ok(())
@@ -565,7 +565,7 @@ impl<'a, T, N> Handler<'a, T, N>
                               instruction: &'a [u8],
                               pid: EnvId)
                               -> PassResult<'a> {
-        InstructionIs(instruction, CURSOR_POSITIONEDQ)?;
+        return_unless_instructions_equal!(instruction, CURSOR_POSITIONEDQ);
         let result = match cursor_map_op!(self, env, pid, get_current, (), |_| Ok(true), |_| false) {
             Ok(true) => STACK_TRUE,
             Err(false) => STACK_FALSE,
@@ -581,7 +581,7 @@ impl<'a, T, N> Handler<'a, T, N>
                              instruction: &'a [u8],
                              pid: EnvId)
                              -> PassResult<'a> {
-        InstructionIs(instruction, CURSOR_KEY)?;
+        return_unless_instructions_equal!(instruction, CURSOR_KEY);
         cursor_map_op!(self, env, pid, get_current, (),
            |(key, _) | {
               let slice = alloc_slice!(key.len(), env);
@@ -597,7 +597,7 @@ impl<'a, T, N> Handler<'a, T, N>
                              instruction: &'a [u8],
                              pid: EnvId)
                              -> PassResult<'a> {
-        InstructionIs(instruction, CURSOR_VAL)?;
+        return_unless_instructions_equal!(instruction, CURSOR_VAL);
         cursor_map_op!(self, env, pid, get_current, (),
            |(_, val) | {
               let slice = alloc_slice!(val.len(), env);
@@ -613,7 +613,7 @@ impl<'a, T, N> Handler<'a, T, N>
                              instruction: &'a [u8],
                              _: EnvId)
                              -> PassResult<'a> {
-        InstructionIs(instruction, MAXKEYSIZE)?;
+        return_unless_instructions_equal!(instruction, MAXKEYSIZE);
         let slice = alloc_and_write!(self.maxkeysize.as_slice(), env);
         env.push(slice);
         Ok(())

--- a/pumpkindb_engine/src/script/mod_string.rs
+++ b/pumpkindb_engine/src/script/mod_string.rs
@@ -5,7 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
-            offset_by_size, InstructionIs, TryInstruction};
+            offset_by_size, TryInstruction};
 
 use ::pumpkinscript::Packable;
 use core::str::FromStr;
@@ -58,7 +58,7 @@ impl<'a> Handler<'a> {
                                instruction: &'a [u8],
                                _: EnvId)
                                -> PassResult<'a> {
-        InstructionIs(instruction, STRING_TO_UINT)?;
+        return_unless_instructions_equal!(instruction, STRING_TO_UINT);
 
         let a_bytes = stack_pop!(env);
         let s = String::from_utf8(Vec::from(a_bytes)).or(Err(error_invalid_value!(a_bytes)))?;
@@ -75,7 +75,7 @@ impl<'a> Handler<'a> {
                           instruction: &'a [u8],
                           _: EnvId)
                           -> PassResult<'a> {
-        InstructionIs(instruction, STRING_TO_INT)?;
+        return_unless_instructions_equal!(instruction, STRING_TO_INT);
 
         let a_bytes = stack_pop!(env);
         let s = String::from_utf8(Vec::from(a_bytes)).or(Err(error_invalid_value!(a_bytes)))?;

--- a/pumpkindb_engine/src/script/mod_uuid.rs
+++ b/pumpkindb_engine/src/script/mod_uuid.rs
@@ -10,7 +10,7 @@ instruction!(UUID_TO_STRING, b"\x8dUUID/->STRING");
 instruction!(UUID_STRING_TO, b"\x8dUUID/STRING->");
 
 use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
-            offset_by_size, InstructionIs, TryInstruction};
+            offset_by_size, TryInstruction};
 
 use core::str::FromStr;
 use uuid::Uuid;
@@ -42,7 +42,7 @@ impl<'a> Handler<'a> {
                           instruction: &'a [u8],
                           _: EnvId)
                           -> PassResult<'a> {
-        InstructionIs(instruction, UUID_V4)?;
+        return_unless_instructions_equal!(instruction, UUID_V4);
         let uuid = Uuid::new_v4();
         let mut slice = alloc_slice!(16, env);
         slice.copy_from_slice(uuid.as_bytes());
@@ -56,7 +56,7 @@ impl<'a> Handler<'a> {
                           instruction: &'a [u8],
                           _: EnvId)
                           -> PassResult<'a> {
-        InstructionIs(instruction, UUID_V5)?;
+        return_unless_instructions_equal!(instruction, UUID_V5);
         let name_bytes = stack_pop!(env);
         if let Ok(name) = str::from_utf8(name_bytes) {
             let ns_uuid_bytes = stack_pop!(env);
@@ -81,7 +81,7 @@ impl<'a> Handler<'a> {
                                  instruction: &'a [u8],
                                  _: EnvId)
                                  -> PassResult<'a> {
-        InstructionIs(instruction, UUID_TO_STRING)?;
+        return_unless_instructions_equal!(instruction, UUID_TO_STRING);
 
         let top = stack_pop!(env);
 
@@ -102,7 +102,7 @@ impl<'a> Handler<'a> {
                                  instruction: &'a [u8],
                                  _: EnvId)
                                  -> PassResult<'a> {
-        InstructionIs(instruction, UUID_STRING_TO)?;
+        return_unless_instructions_equal!(instruction, UUID_STRING_TO);
 
         let top = stack_pop!(env);
 

--- a/pumpkindb_engine/src/script/mod_uuid.rs
+++ b/pumpkindb_engine/src/script/mod_uuid.rs
@@ -10,7 +10,7 @@ instruction!(UUID_TO_STRING, b"\x8dUUID/->STRING");
 instruction!(UUID_STRING_TO, b"\x8dUUID/STRING->");
 
 use super::{Env, EnvId, Dispatcher, PassResult, Error, ERROR_EMPTY_STACK, ERROR_INVALID_VALUE,
-            offset_by_size};
+            offset_by_size, InstructionIs, TryInstruction};
 
 use core::str::FromStr;
 use uuid::Uuid;
@@ -23,11 +23,11 @@ pub struct Handler<'a> {
 
 impl<'a> Dispatcher<'a> for Handler<'a> {
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a> {
-        try_instruction!(env, self.handle_uuid_v4(env, instruction, pid));
-        try_instruction!(env, self.handle_uuid_v5(env, instruction, pid));
-        try_instruction!(env, self.handle_uuid_to_string(env, instruction, pid));
-        try_instruction!(env, self.handle_uuid_string_to(env, instruction, pid));
-        Err(Error::UnknownInstruction)
+        self.handle_uuid_v4(env, instruction, pid)
+        .if_unhandled_try(|| self.handle_uuid_v5(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_uuid_to_string(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_uuid_string_to(env, instruction, pid))
+        .if_unhandled_try(|| Err(Error::UnknownInstruction))
     }
 }
 
@@ -42,7 +42,7 @@ impl<'a> Handler<'a> {
                           instruction: &'a [u8],
                           _: EnvId)
                           -> PassResult<'a> {
-        instruction_is!(instruction, UUID_V4);
+        InstructionIs(instruction, UUID_V4)?;
         let uuid = Uuid::new_v4();
         let mut slice = alloc_slice!(16, env);
         slice.copy_from_slice(uuid.as_bytes());
@@ -56,7 +56,7 @@ impl<'a> Handler<'a> {
                           instruction: &'a [u8],
                           _: EnvId)
                           -> PassResult<'a> {
-        instruction_is!(instruction, UUID_V5);
+        InstructionIs(instruction, UUID_V5)?;
         let name_bytes = stack_pop!(env);
         if let Ok(name) = str::from_utf8(name_bytes) {
             let ns_uuid_bytes = stack_pop!(env);
@@ -81,7 +81,7 @@ impl<'a> Handler<'a> {
                                  instruction: &'a [u8],
                                  _: EnvId)
                                  -> PassResult<'a> {
-        instruction_is!(instruction, UUID_TO_STRING);
+        InstructionIs(instruction, UUID_TO_STRING)?;
 
         let top = stack_pop!(env);
 
@@ -102,7 +102,7 @@ impl<'a> Handler<'a> {
                                  instruction: &'a [u8],
                                  _: EnvId)
                                  -> PassResult<'a> {
-        instruction_is!(instruction, UUID_STRING_TO);
+        InstructionIs(instruction, UUID_STRING_TO)?;
 
         let top = stack_pop!(env);
 


### PR DESCRIPTION
Specifically, `try_instruction!` and `instruction_is!` do not
communicate the fact that, given certain conditions (result-worthy
instruction invocaton or matching instruction name) they will
`return` a PassResult from the function that uses the macro.

This makes it harder to understand the flow of the code, unless
you're intimately familiar with these macros.

Solution: use `Try` trait (via `InstructionIs` struct -- arguably,
not the best name, please submit a PR if you can think of a better one)
and `?` syntax to indicate that in case of an error, the function
will be terminated and the error will be returned.

Also, add a `TryInstruction` trait that allows to build a chain
of handlers for instructions that couldn't be handled. These chains
will communicate the flow of the code more naturally.