### PR TITLE
Problem: PumpkinDB scheduler is still slow

### DIFF
--- a/pumpkindb_engine/src/script/env.rs
+++ b/pumpkindb_engine/src/script/env.rs
@@ -87,7 +87,7 @@ impl<'a> Env<'a> {
 
     /// Returns a copy of the entire stack
     #[inline]
-    pub fn stack_copy(self) -> Vec<Vec<u8>> {
+    pub fn stack_copy(&self) -> Vec<Vec<u8>> {
         self.stack[0..self.stack_size as usize].into_iter().map(|v| Vec::from(*v)).collect()
     }
 


### PR DESCRIPTION
Solution: avoid moving Envs out of the scheduler's queue

Instead, Envs can be borrowed mutably to be scheduled. After
that, in order to avoid removing an Env from the queue only
to reschedule it to the back of the queue, the Env is swapped
with another randomly chosen Env.

This gives a considerable (~25%) performance boost. Before:

```
test script::tests::ackermann                                                  ... bench:  36,458,409 ns/iter (+/- 2,681,453)
test script::tests::ackermann_stack                                            ... bench:  27,938,938 ns/iter (+/- 2,885,146)
```

After:

```
test script::tests::ackermann                                                  ... bench:  28,170,244 ns/iter (+/- 3,726,782)
test script::tests::ackermann_stack                                            ... bench:  22,269,071 ns/iter (+/- 2,800,322)
```