### PR TITLE
Problem: can't use `TryInstruction` trait in third-party projects

### DIFF
--- a/pumpkindb_engine/src/script/mod.rs
+++ b/pumpkindb_engine/src/script/mod.rs
@@ -88,7 +88,7 @@ instruction!(TRY_END, b"\x80\x83TRY"); // internal instruction
 
 include!("macros.rs");
 
-trait TryInstruction {
+pub trait TryInstruction {
     fn if_unhandled_try<F>(self, f: F) -> Result<(), Error> where F: FnOnce() -> Result<(), Error>;
     fn is_unhandled(&self) -> bool;
 }


### PR DESCRIPTION
```
error[E0603]: trait `TryInstruction` is private
```

Solution: make it public