### PR TITLE
Problem: in some cases, operating on stack triplets is useful

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -6,7 +6,9 @@
  * Stack manipulation
    * [-ROT](script/-ROT.md)
    * [2DROP](script/2DROP.md)
+   * [3DROP](script/3DROP.md)
    * [2DUP](script/2DUP.md)
+   * [3DUP](script/3DUP.md)
    * [2NIP](script/2NIP.md)
    * [2OVER](script/2OVER.md)
    * [2ROT](script/2ROT.md)

--- a/doc/script/3DROP.md
+++ b/doc/script/3DROP.md
@@ -1,0 +1,38 @@
+# 3DROP
+
+{% method -%}
+
+Drops three topmost items off the top of the stack
+
+Input stack: `a b c`
+
+Output stack: -
+
+{% common -%}
+
+In this example, three items (`0`, `1` and `2`) are dropped from the stack,
+leaving the forth element on the top of the stack.
+
+```
+PumpkinDB> 0 0 1 2 3DROP
+0
+```
+
+{% endmethod %}
+
+## Allocation
+
+None
+
+## Errors
+
+[EmptyStack](./errors/EmptyStack.md) error if there are less than three items available on the stack
+
+## Tests
+
+```test
+3drop_drops_three_items : 1 2 3 3DROP STACK LENGTH 0 EQUAL?.
+3drop_requires_three_items_0 : [3DROP] TRY UNWRAP 0x04 EQUAL?.
+3drop_requires_three_items_1 : [2 3DROP] TRY UNWRAP 0x04 EQUAL?.
+3drop_requires_three_items_2 : [1 2 3DROP] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/3DUP.md
+++ b/doc/script/3DUP.md
@@ -1,0 +1,38 @@
+# 3DUP
+
+{% method -%}
+
+Duplicates the triplet of three topmost items
+
+Input stack: `a bc `
+
+Output stack: `a b c a b c`
+
+{% common -%}
+
+In this example, a triplet of three items (`0x00`, ``0x10`, `0x20`) is
+duplicated.
+
+```
+PumpkinDB> 0x00 0x10 0x20 3DUP
+0x00 0x10 0x20 0x00 0x10 0x20 
+```
+
+{% endmethod %}
+
+## Allocation
+
+None
+
+## Errors
+
+[EmptyStack](./errors/EmptyStack.md) error if there are less than three items available on the stack
+
+## Tests
+
+```test
+3dup_copies_a_pair : 0x00 0x10 0x20 3DUP 6 WRAP 0x010001100120010001100120 EQUAL?.
+3dup_requires_three_items_0 : [3DUP] TRY UNWRAP 0x04 EQUAL?.
+3dup_requires_three_items_1 : [1 3DUP] TRY UNWRAP 0x04 EQUAL?.
+3dup_requires_three_items_2 : [1 2 3DUP] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/pumpkindb_engine/src/script/mod_stack.rs
+++ b/pumpkindb_engine/src/script/mod_stack.rs
@@ -13,6 +13,8 @@ use pumpkinscript;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 
+instruction!(THREEDROP, (a, b, c => ), b"\x853DROP");
+instruction!(THREEDUP, (a, b, c => a, b, c), b"\x843DUP");
 instruction!(DROP, (a => ), b"\x84DROP");
 instruction!(DUP, (a => a, a), b"\x83DUP");
 instruction!(SWAP, (a, b => b, a), b"\x84SWAP");
@@ -36,6 +38,8 @@ impl<'a> Dispatcher<'a> for Handler<'a> {
         self.handle_builtins(env, instruction, pid)
         .if_unhandled_try(|| self.handle_drop(env, instruction, pid))
         .if_unhandled_try(|| self.handle_dup(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_3drop(env, instruction, pid))
+        .if_unhandled_try(|| self.handle_3dup(env, instruction, pid))
         .if_unhandled_try(|| self.handle_swap(env, instruction, pid))
         .if_unhandled_try(|| self.handle_2swap(env, instruction, pid))
         .if_unhandled_try(|| self.handle_rot(env, instruction, pid))
@@ -63,6 +67,25 @@ impl<'a> Handler<'a> {
 
         env.push(v);
         env.push(v);
+        Ok(())
+    }
+
+
+    #[inline]
+    fn handle_3dup(&mut self, env: &mut Env<'a>, instruction: &'a [u8], _: EnvId) -> PassResult<'a> {
+        return_unless_instructions_equal!(instruction, THREEDUP);
+        let c = stack_pop!(env);
+        let b = stack_pop!(env);
+        let a = stack_pop!(env);
+
+        env.push(a);
+        env.push(b);
+        env.push(c);
+
+        env.push(a);
+        env.push(b);
+        env.push(c);
+
         Ok(())
     }
 
@@ -187,6 +210,20 @@ impl<'a> Handler<'a> {
                    _: EnvId)
                    -> PassResult<'a> {
         return_unless_instructions_equal!(instruction, DROP);
+        let _ = stack_pop!(env);
+
+        Ok(())
+    }
+
+    #[inline]
+    fn handle_3drop(&mut self,
+                   env: &mut Env<'a>,
+                   instruction: &'a [u8],
+                   _: EnvId)
+                   -> PassResult<'a> {
+        return_unless_instructions_equal!(instruction, THREEDROP);
+        let _ = stack_pop!(env);
+        let _ = stack_pop!(env);
         let _ = stack_pop!(env);
 
         Ok(())


### PR DESCRIPTION
For example, I am currently working on ViewDB and my core
attribute processing instruction (`ATTR`) takes three elements
off the stack (id, attribute, value) and needs to pass them
to another instruction before operating on them itself.

Solution: implement `3DUP` and `3DROP` instructions that are
found in some Forth extensions. The good thing is that they
are following the same convention as `2DUP` and `2DROP` so it
is easy to guess what they do.