### PR TITLE
Problem: scheduler swaps current Env for the one before the last one

### DIFF
--- a/pumpkindb_engine/src/script/mod.rs
+++ b/pumpkindb_engine/src/script/mod.rs
@@ -390,7 +390,7 @@ impl<'a, T: Dispatcher<'a>> Scheduler<'a, T> {
                     let index: usize = rng.gen_range(1, len);
                     // Swapping is used to avoid removing elements
                     // from the queue
-                    envs.swap(0, len - 1);
+                    envs.swap(0, index);
                 }
             }
             let message = if envs.is_empty() {


### PR DESCRIPTION
@dhardy noticed this https://github.com/PumpkinDB/PumpkinDB/pull/329
(thanks!) and it definitely doesn't make sense.

The original plan was to use the randomly chosen index.

Solution: use the index instead of `len - 1`