### PR TITLE
Problem: `CURSOR/SEEK` instruction is not documented

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -47,6 +47,7 @@
    * [CURSOR/FIRST](script/CURSOR/FIRST.md)
    * [CURSOR/LAST](script/CURSOR/LAST.md)
    * [CURSOR/NEXT](script/CURSOR/NEXT.md)
+   * [CURSOR/SEEK](script/CURSOR/SEEK.md)
    * [CURSOR/SEEKLAST](script/CURSOR/SEEKLAST.md)
    * [CURSOR/POSITIONED?](script/CURSOR/POSITIONEDQ.md)
    * [CURSOR/KEY](script/CURSOR/KEY.md)


### PR DESCRIPTION
Solution: In fact, it is documented but wasn't included into the
table of contents, giving the impression of not being documented.
This adds the instruction to the list.