### PR TITLE
Problem: `TXID` manual doesn't specify identifier's length

### DIFF
--- a/doc/script/TXID.md
+++ b/doc/script/TXID.md
@@ -15,6 +15,9 @@ to do this by retrieving ongoing transaction's ID
 Transaction identifiers are guaranteed to be unique and grow monotonically,
 thus allowing one to compare the order of their origination.
 
+Exact length is not guaranteed, however, for the purpose of comparability,
+it is guaranteed that all transaction identifiers are of the same length.
+
 {% common -%}
 
 ```


### PR DESCRIPTION
Solution: specifying a specific length is potentially problematic.
Currently we use `HLC` to fulfill the obligations of `TXID`, but
this can eventually change (or not, hard to predict!).

However, it is important to provide certain guarantees about it. In
order to make all transaction identifiers perfectly comparable, they
are guaranteed to have a constant size.

This has been clarified in the documentation.