### PR TITLE
Problem: used nightly Rust is over a month old

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - stable
-  - nightly-2017-06-19
+  - nightly-2017-07-24
 matrix:
   allow_failures:
     - rust: stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   matrix:
     - channel: stable
       target: x86_64-pc-windows-msvc
-    - channel: nightly-2017-06-19
+    - channel: nightly-2017-07-24
       target: x86_64-pc-windows-msvc
 
 matrix:

--- a/pumpkindb_engine/src/lib.rs
+++ b/pumpkindb_engine/src/lib.rs
@@ -6,7 +6,7 @@
 #![feature(slice_patterns, advanced_slice_patterns)]
 
 #![cfg_attr(test, feature(test))]
-#![cfg_attr(not(target_os = "windows"), feature(alloc, heap_api))]
+#![cfg_attr(not(target_os = "windows"), feature(alloc))]
 #![feature(alloc)]
 
 include!("crates.rs");

--- a/pumpkindb_server/Cargo.toml
+++ b/pumpkindb_server/Cargo.toml
@@ -13,6 +13,7 @@ authors = ["Yurii Rashkovskii <yrashk@gmail.com>"]
 [[bin]]
 doc = false
 name = "pumpkindb"
+path = "src/main.rs"
 
 [dependencies]
 clap = "2.22.1"

--- a/pumpkindb_term/Cargo.toml
+++ b/pumpkindb_term/Cargo.toml
@@ -12,6 +12,7 @@ authors = ["Yurii Rashkovskii <yrashk@gmail.com>"]
 [[bin]]
 doc = false
 name = "pumpkindb-term"
+path = "src/main.rs"
 
 [dependencies]
 config = "0.3.1"

--- a/tests/doctests/Cargo.toml
+++ b/tests/doctests/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 [[bin]]
 doc = false
 name = "pumpkindb-doctests"
+path = "src/main.rs"
 
 [dependencies]
 glob = "0.2.11"


### PR DESCRIPTION
Solution: update to the most recent nightly build

Encountered two issues while doing this:

1. `heap::{allocate, deallocate}` functions were no longer found;
   As a result, a much simpler solution was used in order to avoid
   using this unstable API, namely, just using `mem::zeroed()` to
   initialize `statvfs` structure.
2. Cargo started producing warnings about implicit definitions for
   `bin.path` so it is now set manually to silence Cargo.