### PR TITLE
Problem: using `heap::allocate` API

### DIFF
--- a/pumpkindb_engine/src/lib.rs
+++ b/pumpkindb_engine/src/lib.rs
@@ -6,7 +6,7 @@
 #![feature(slice_patterns, advanced_slice_patterns)]
 
 #![cfg_attr(test, feature(test))]
-#![cfg_attr(not(target_os = "windows"), feature(alloc, heap_api))]
+#![cfg_attr(not(target_os = "windows"), feature(alloc))]
 #![feature(alloc)]
 
 include!("crates.rs");


### PR DESCRIPTION
Firstly, this API is unstable and can change or be removed any time.

Secondly, it is really a cumbersome way to initialize a c structure.

Solution: use `std::mem::zeroed` instead

See #336