### PR TITLE
Problem: current Rust nightly affects benchmarks negatively

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - stable
-  - nightly-2017-07-24
+  - nightly-2017-06-20
 matrix:
   allow_failures:
     - rust: stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   matrix:
     - channel: stable
       target: x86_64-pc-windows-msvc
-    - channel: nightly-2017-07-24
+    - channel: nightly-2017-06-20
       target: x86_64-pc-windows-msvc
 
 matrix:


### PR DESCRIPTION
*2017-07-24*:

```
test script::tests::ackermann                                                  ... bench:  49,617,433 ns/iter (+/- 6,028,955)
test script::tests::ackermann_stack                                            ... bench:  36,797,438 ns/iter (+/- 4,442,438)
```

*2017-07-01*:

```
test script::tests::ackermann                                                  ... bench:  97,953,353 ns/iter (+/- 5,756,554)
test script::tests::ackermann_stack                                            ... bench:  51,599,955 ns/iter (+/- 3,756,541)
```

*2017-07-12*:

```
test script::tests::ackermann                                                  ... bench:  50,183,660 ns/iter (+/- 7,364,549)
test script::tests::ackermann_stack                                            ... bench:  39,244,258 ns/iter (+/- 6,607,862)
```

*2017-06-23*:

```
test script::tests::ackermann                                                  ... bench: 111,698,229 ns/iter (+/- 17,495,313)
test script::tests::ackermann_stack                                            ... bench:  58,807,694 ns/iter (+/- 4,591,336)
```

*nightly-2017-06-20*:

```
test script::tests::ackermann                                                  ... bench:  32,562,056 ns/iter (+/- 4,313,209)
test script::tests::ackermann_stack                                            ... bench:  24,391,250 ns/iter (+/- 4,758,534)
```

**nightly-2017-06-21**: (https://github.com/rust-lang/rust/commit/445077963)

```
test script::tests::ackermann                                                  ... bench:  99,398,843 ns/iter (+/- 5,556,874)
test script::tests::ackermann_stack                                            ... bench:  51,625,752 ns/iter (+/- 3,971,108)
```

See #336 for details

Solution: use the last known "good" build (2017-06-20)