### PR TITLE
Problem: sharing stack with closures prevents typing

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -25,6 +25,10 @@
    * [TUCK](script/TUCK.md)
    * [UNWRAP](script/UNWRAP.md)
    * [WRAP](script/WRAP.md)
+   * [<](script/PUSH.md)
+   * [>](script/POP.md)
+   * [>R](script/TO_R.md)
+   * [R>](script/FROM_R.md)
  * Logical operations
    * [AND](script/AND.md)
    * [EQUAL?](script/EQUALQ.md)

--- a/doc/script/CURSOR/DOWHILE-PREFIXED.md
+++ b/doc/script/CURSOR/DOWHILE-PREFIXED.md
@@ -13,6 +13,9 @@ equal or grater than `prefix` and execute `closure` while it leaves `1` on the
 top of the stack, invoking `CURSOR/NEXT` on the `cursor` after each run. The closure
 should be written with an expectation of the cursor on top of the stack.
 
+`CURSOR/DOWHILE-PREFIXED` evaluates the closure on a new stack, popping the
+current stack back after each evaluation.
+
 {% common -%}
 
 ```
@@ -22,8 +25,8 @@ PumpkinDB> ["a" HLC CONCAT 0 ASSOC
               "testkey" HLC CONCAT 3 ASSOC
               "z" HLC CONCAT 4 ASSOC
               COMMIT] WRITE
-             ["testkey" [CURSOR/VAL TRUE] CURSOR/DOWHILE-PREFIXED] READ
-0x01 0x02 0x03             
+             ["testkey" [CURSOR/VAL >R TRUE] CURSOR/DOWHILE-PREFIXED] READ R> R> R>
+0x03 0x02 0x01
 ```
 
 {% endmethod %}
@@ -48,12 +51,14 @@ cursor_dowhile_prefixed :
    "testkey" HLC CONCAT 3 ASSOC
    "z" HLC CONCAT 4 ASSOC
    COMMIT] WRITE
-  ["testkey" [CURSOR/VAL TRUE] CURSOR/DOWHILE-PREFIXED] READ
-  3 WRAP [1 2 3] EQUAL?.
+  ["testkey" [CURSOR/VAL >R TRUE] CURSOR/DOWHILE-PREFIXED] READ
+  R> R> R>
+  3 WRAP [3 2 1] EQUAL?.
 nextkey_short : ["key" HLC CONCAT 1 ASSOC
                "key" HLC CONCAT 2 ASSOC
                "key" HLC CONCAT 3 ASSOC
                "z" 4 ASSOC COMMIT] WRITE
-          ["key" [CURSOR/VAL TRUE] CURSOR/DOWHILE-PREFIXED] READ
-          3 WRAP [1 2 3] EQUAL?.
+          ["key" [CURSOR/VAL >R TRUE] CURSOR/DOWHILE-PREFIXED] READ
+          R> R> R>
+          3 WRAP [3 2 1] EQUAL?.
 ```

--- a/doc/script/CURSOR/DOWHILE.md
+++ b/doc/script/CURSOR/DOWHILE.md
@@ -12,6 +12,9 @@ Output stack:
 top of the stack, invoking `iterator` on the `cursor` after each run. 
 The closure should be written with the expectation of the cursor on the top of the stack.
 
+`CURSOR/DOWHILE` evaluates the closure on a new stack, popping the
+current stack back after each evaluation.
+
 {% common -%}
 
 ```
@@ -21,8 +24,8 @@ PumpkinDB> ["testkey" HLC CONCAT 1 ASSOC
    "z" HLC CONCAT 4 ASSOC
    COMMIT] WRITE
   [CURSOR DUP CURSOR/FIRST DROP
-     [CURSOR/VAL TRUE] 'CURSOR/NEXT CURSOR/DOWHILE] READ
-0x01 0x02 0x03 0x04   
+     [CURSOR/VAL >R TRUE] 'CURSOR/NEXT CURSOR/DOWHILE] READ R> R> R>
+0x04 0x03 0x02 0x01
 ```
 
 {% endmethod %}
@@ -47,6 +50,7 @@ cursor_dowhile :
    "z" HLC CONCAT 4 ASSOC
    COMMIT] WRITE
   [CURSOR DUP CURSOR/FIRST DROP
-   [CURSOR/VAL TRUE] 'CURSOR/NEXT CURSOR/DOWHILE] READ
-  4 WRAP [1 2 3 4] EQUAL?.
+   [CURSOR/VAL >R TRUE] 'CURSOR/NEXT CURSOR/DOWHILE] READ
+  R> R> R> R> 
+  4 WRAP [4 3 2 1] EQUAL?.
 ```

--- a/doc/script/DOWHILE.md
+++ b/doc/script/DOWHILE.md
@@ -8,10 +8,14 @@ Input stack: `code`
 
 Output stack:
 
+`DOWHILE` evaluates the closure on a new stack, popping the
+current stack back after each evaluation.
+
 {% common -%}
 
 ```
-PumpkinDB> 1 2 3 [1 EQUAL? NOT] DOWHILE
+PumpkinDB> 1 >R [R> 1 UINT/ADD DUP >R 4 EQUAL? NOT] DOWHILE R> 
+4
 ```
 
 {% endmethod %}
@@ -31,7 +35,7 @@ Runtime allocation for code generation
 ## Tests
 
 ```test
-works : 1 2 3 [1 EQUAL? NOT] DOWHILE DEPTH 0 EQUAL?.
+works : 1 >R [R> 1 UINT/ADD DUP >R 4 EQUAL? NOT] DOWHILE R> 4 EQUAL?.
 invalid_code : [1 DOWHILE] TRY UNWRAP 0x05 EQUAL?.
 invalid_value : [[5] DOWHILE] TRY UNWRAP 0x03 EQUAL?.
 empty_stack : [DOWHILE] TRY UNWRAP 0x04 EQUAL?.

--- a/doc/script/EVAL.md
+++ b/doc/script/EVAL.md
@@ -9,6 +9,8 @@ Input stack: `code`
 
 Output stack: result of `code` evaluation
 
+`EVAL` evaluates the closure on the current stack.
+
 {% common -%}
 
 ```

--- a/doc/script/EVAL/SCOPED.md
+++ b/doc/script/EVAL/SCOPED.md
@@ -17,6 +17,8 @@ one important distinction: all new instructions defined inside
 evaluation (using [SET](../SET.md) and [DEF](../DEF.md)) will be
 gone after the evaluation.  
 
+`EVAL/SCOPED` evaluates the closure on the current stack.
+
 {% common -%}
 
 ```

--- a/doc/script/FROM_R.md
+++ b/doc/script/FROM_R.md
@@ -1,0 +1,37 @@
+# R\>
+
+Pronounced "from R"
+
+{% method -%}
+
+Pops a value from the return stack. Used in conjunction with [>R](TO_R.md), mostly
+to pass values into and out of evaluated closures (although can be sometimes used for other purposes
+as well)
+
+Input stack: `a`
+
+Output stack: -
+
+{% common -%}
+
+```
+PumpkinDB> [1 >R] EVAL R>
+1
+```
+
+{% endmethod %}
+
+## Allocation
+
+None
+
+## Errors
+
+[EmptyStack](./errors/EmptyStack.md) error if the return stack is empty
+
+## Tests
+
+```test
+works : 1 >R 2 R> 1 EQUAL?.
+empty_stack : [R>] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/IF.md
+++ b/doc/script/IF.md
@@ -10,6 +10,7 @@ Output stack: maybe `b`
 
 `IF` will push the result `[b]` to the stack if `a` is `1`.
 
+`IF` evaluates the branch closure on the current stack.
 {% common -%}
 
 ```

--- a/doc/script/IFELSE.md
+++ b/doc/script/IFELSE.md
@@ -12,6 +12,7 @@ Output stack: maybe `b`, maybe `c`
 `IFELSE` will push the result of `[c]` to the stack if `a` is 0, or it
 will push `[b]` otherwise.
 
+`IFELSE` evaluates the branches closures on the current stack.
 {% common -%}
 
 ```

--- a/doc/script/POP.md
+++ b/doc/script/POP.md
@@ -1,0 +1,39 @@
+# \> (POP)
+
+{% method -%}
+
+Pops the topmost stack off the stack of stacks and makes it a current
+stack. Previously current stack is discarded. Used in conjunction with [<](PUSH.md)
+
+Input stack: -
+
+Output stack: -
+
+This instruction should not be used lightly as it is primarily an
+internal mechanism for managing distinct stacks. It will not be
+a part of future Typed PumpkinScript as it will be typed around a single stack.
+
+{% common -%}
+
+```
+PumpkinDB> 1 2 < 3 >
+1 2 
+```
+
+{% endmethod %}
+
+## Allocation
+
+None
+
+## Errors
+
+[EmptyStack](./errors/EmptyStack.md) error if there are no stacks that were previously
+pushed onto the stack of stacks.
+
+## Tests
+
+```test
+restore : 1 2 3 4 < < > > DEPTH 4 EQUAL?.
+empty_stack : [>] TRY UNWRAP 0x04 EQUAL?.
+```

--- a/doc/script/PUSH.md
+++ b/doc/script/PUSH.md
@@ -1,0 +1,35 @@
+# \< (PUSH)
+
+{% method -%}
+
+Pushes current stack on the stack of stacks and makes an empty stack
+available as the current stack. Used in conjunction with [>](POP.md)
+
+This instruction should not be used lightly as it is primarily an
+internal mechanism for managing distinct stacks. It will not be
+a part of future Typed PumpkinScript as it will be typed around a single stack.
+
+Input stack: -
+
+Output stack: -
+
+{% common -%}
+
+```
+PumpkinDB> 1 2 < 3 >
+1 2 
+```
+
+{% endmethod %}
+
+## Allocation
+
+Allocates a new empty stack
+
+## Errors
+
+## Tests
+
+```test
+works : 1 2 3 4 < DEPTH 0 EQUAL?.
+```

--- a/doc/script/READ.md
+++ b/doc/script/READ.md
@@ -14,6 +14,8 @@ a READ or a [WRITE](WRITE.md).
 
 The total number of simultaneous read transactions is limited to 126.
 
+`READ` evaluates the closure on the current stack.
+
 {% common -%}
 
 ```

--- a/doc/script/TIMES.md
+++ b/doc/script/TIMES.md
@@ -9,6 +9,9 @@ Input stack: `code n`
 
 Output stack: result of `code` evaluation done `n` times
 
+`TIMES` evaluates the closure on a new stack and pops the previous
+stack after each evaluation.
+
 {% common -%}
 
 ```
@@ -31,8 +34,8 @@ Allocates for recursion during runtime.
 ## Tests
 
 ```test
-works : [10] 3 TIMES STACK [10 10 10] EQUAL?.
-works_0 : [10] 0 TIMES STACK LENGTH 0 EQUAL?.
+works : [10 >R] 3 TIMES R> R> R> STACK [10 10 10] EQUAL?.
+works_0 : [10 >R] 0 TIMES [R>] TRY UNWRAP 0x04 EQUAL?.
 empty_stack : [TIMES] TRY UNWRAP 0x04 EQUAL?.
 empty_stack_1 : [1 TIMES] TRY UNWRAP 0x04 EQUAL?.
 invalid_code : [1 1 TIMES] TRY UNWRAP 0x05 EQUAL?.

--- a/doc/script/TO_R.md
+++ b/doc/script/TO_R.md
@@ -1,0 +1,34 @@
+# \>R
+
+Pronounced "to R"
+
+{% method -%}
+
+Pushes a value onto the return stack. Used in conjunction with [R>](FROM_R.md), mostly
+to pass values into and out of evaluated closures (although can be sometimes used for other purposes
+as well)
+
+Input stack: `a`
+
+Output stack: -
+
+{% common -%}
+
+```
+PumpkinDB> [1 >R] EVAL R>
+1
+```
+
+{% endmethod %}
+
+## Allocation
+
+None
+
+## Errors
+
+## Tests
+
+```test
+works : 1 >R 2 R> 1 EQUAL?.
+```

--- a/doc/script/TRY.md
+++ b/doc/script/TRY.md
@@ -13,6 +13,8 @@ the closure but will not fail the program if there was an error.
 Instead, it will push an error closure onto the stack. If no error
 occurred, `[]` (an empty closure) will be pushed onto the stack.
 
+`TRY` evaluates the closure on the current stack.
+
 {% common -%}
 
 ```

--- a/doc/script/WRITE.md
+++ b/doc/script/WRITE.md
@@ -16,6 +16,8 @@ can also be used.
 
 The total number of simultaneous write transactions is limited to one.
 
+`WRITE` evaluates the closure on the current stack.
+
 {% common -%}
 
 ```

--- a/pumpkindb_engine/src/script/dispatcher.rs
+++ b/pumpkindb_engine/src/script/dispatcher.rs
@@ -249,7 +249,7 @@ mod tests {
                   for i in 0..(&stack).len() {
                       stack_.push((&stack[i]).as_slice());
                   }
-                  let mut script_env = Env::new_with_stack(stack_, stack_size).unwrap();
+                  let mut script_env = Env::new_with_stack(stack_).unwrap();
                   let val = script_env.pop().unwrap();
                   assert_eq!(val, b"TEST");
               },

--- a/pumpkindb_engine/src/script/macros.rs
+++ b/pumpkindb_engine/src/script/macros.rs
@@ -295,7 +295,7 @@ macro_rules! eval {
                       for i in 0..(&stack).len() {
                           stack_.push((&stack[i]).as_slice());
                       }
-                      let mut $env = Env::new_with_stack(stack_, stack_size).unwrap();
+                      let mut $env = Env::new_with_stack(stack_).unwrap();
                       $expr;
                    }
                    Ok(ResponseMessage::EnvFailed(_, err, stack, stack_size)) => {
@@ -307,7 +307,7 @@ macro_rules! eval {
                       for i in 0..(&stack).len() {
                           stack_.push((&stack)[i].as_slice());
                       }
-                      let mut $env = Env::new_with_stack(stack_, stack_size.unwrap()).unwrap();
+                      let mut $env = Env::new_with_stack(stack_).unwrap();
                       $expr;
                    }
                    Err(err) => {

--- a/pumpkindb_engine/src/script/mod.rs
+++ b/pumpkindb_engine/src/script/mod.rs
@@ -79,7 +79,7 @@ macro_rules! instruction {
     ($name : ident,
     $ident : expr) =>
     (
-     const $name : &'static[u8] = $ident;
+     pub(crate) const $name : &'static[u8] = $ident;
     )
 }
 
@@ -356,7 +356,7 @@ impl<'a, T: Dispatcher<'a>> Scheduler<'a, T> {
                         }
                         Err(err) => {
                             self.dispatcher.done(env, pid);
-                            let stack_size = env.stack_size;
+                            let stack_size = env.stack().len();
                             let _ = chan.send(ResponseMessage::EnvFailed(pid,
                                                                          err,
                                                                          Some(env.stack_copy()),
@@ -367,7 +367,7 @@ impl<'a, T: Dispatcher<'a>> Scheduler<'a, T> {
                             if env.program.is_empty() ||
                                 (env.program.len() == 1 && env.program[0].len() == 0) {
                                 self.dispatcher.done(env, pid);
-                                let stack_size = env.stack_size;
+                                let stack_size = env.stack().len();
                                 let _ = chan.send(ResponseMessage::EnvTerminated(pid,
                                                                                  env.stack_copy(),
                                                                                  stack_size));

--- a/pumpkindb_engine/src/script/mod_storage.rs
+++ b/pumpkindb_engine/src/script/mod_storage.rs
@@ -662,7 +662,7 @@ mod tests {
 
     #[test]
     fn txn_order() {
-        eval!("\"hello\" HLC CONCAT DUP [\"world\" ASSOC [ASSOC?] READ] WRITE 0x00 EQUAL?", env, result, {
+        eval!("[\"hello\" HLC CONCAT DUP \"world\" ASSOC [ASSOC?] READ] WRITE 0x00 EQUAL?", env, result, {
             assert_eq!(Vec::from(env.pop().unwrap()), parsed_data!("0x01"));
             assert_eq!(env.pop(), None);
         });
@@ -672,7 +672,7 @@ mod tests {
 
     #[bench]
     fn write_1000_kv_pairs_in_isolated_txns(b: &mut Bencher) {
-        bench_eval!("[HLC \"Hello\"] 1000 TIMES [[ASSOC COMMIT] WRITE] 1000 TIMES",
+        bench_eval!("[\"Hello\" >R HLC >R] 1000 TIMES [[R> R> ASSOC COMMIT] WRITE] 1000 TIMES",
                     b);
     }
 

--- a/tests/doctests/src/main.rs
+++ b/tests/doctests/src/main.rs
@@ -58,14 +58,14 @@ fn eval(name: &[u8], script: &[u8], timestamp: Arc<timestamp::Timestamp<nvmem::M
         sender.schedule_env(EnvId::new(), Vec::from(script), callback,
                                                         Box::new(sender0));
         match receiver.recv() {
-            Ok(ResponseMessage::EnvTerminated(_, stack, stack_size)) => {
+            Ok(ResponseMessage::EnvTerminated(_, stack, _)) => {
                 sender.shutdown();
                 simple_accessor.shutdown();
                 let mut stack_ = Vec::with_capacity(stack.len());
                 for i in 0..(&stack).len() {
                     stack_.push((&stack[i]).as_slice());
                 }
-                let mut script_env = Env::new_with_stack(stack_, stack_size).unwrap();
+                let mut script_env = Env::new_with_stack(stack_).unwrap();
                 let val = script_env.pop().unwrap();
                 assert_eq!(Vec::from(val),
                            vec![1],


### PR DESCRIPTION
I've attempted to develop a simple typing inference mechanism for PumpkinScript
(https://github.com/yrashk/PumpkinDB/commit/d6c1e4617ac59575de65ddcebc630bac5d57c773)
but our closure evaluation rules prevent me from finishing it.

Basically, closures consume from the stack and push to the stack, and since we
don't know how many times a closure will be executed (can be anywhere between
zero and `n`), we don't really know how to infer or check type of subsequent
instructions.

Solution: instructions that evaluate closures a number of times that
is unknown compile-time have to evaluate these closures on a separate stack.

By only allowing such closures to communicate with the rest of the program
in a linear way, we can infer types. Also, it seems like a much cleaner
approach as well.

What has been done to implement this:

1. A concept of a stack of stacks was added, with corresponding "push" (`<`) and
"pop" (`>') instructions. This syntax was chosen to serve as a visual indicator of
stack separation:

    1 < ... > DUP

These instructions are mainly intended for internal use but because sometimes they
can be a great mechanism for other problems, they were made public.

This allows us to run such closures in new stacks and return to previous stacks.

2. In order to allow such closures to communicate return values linearly, Forth's
concept of a return stack with corresponding `>R` ("to R") and `R>` ("from R") instructions
were implemented. By only allowing to read one value at a time, we can infer the value type
by value's subsequent use (or type it through casting)

Note that the properties/guidelines for this return stack are different from Forth's,
as its primary motivation is communicating across "boundaries". For that reason,
if a better name will be found, it might be renamed to avoid the confusion.

3. The introduction of multiple stacks exacerbated dubious stack vector pre-allocation
technique, instructions like `TIMES` were getting really slow. By removing this technique,
we've simplified code and made new stack allocation much faster.

THIS IS A BREAKING CHANGE.

Closes #339