### PR TITLE
Problem: PumpkinDB does not build on current rust toolchain.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - stable
-  - nightly-2017-06-20
+  - nightly-2019-05-01
 matrix:
   allow_failures:
     - rust: stable

--- a/pumpkindb_engine/Cargo.toml
+++ b/pumpkindb_engine/Cargo.toml
@@ -39,7 +39,7 @@ pumpkinscript = { version = "0.2", path = "../pumpkinscript" }
 
 [dev-dependencies]
 quickcheck = "0.4.1"
-quickcheck_macros = "0.4.1"
+quickcheck_macros = "0.8.0"
 matches = "0.1.4"
 
 [features]

--- a/pumpkindb_engine/src/lib.rs
+++ b/pumpkindb_engine/src/lib.rs
@@ -3,10 +3,9 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#![feature(slice_patterns, advanced_slice_patterns)]
+#![feature(slice_patterns, raw_vec_internals)]
 
 #![cfg_attr(test, feature(test))]
-#![cfg_attr(not(target_os = "windows"), feature(alloc))]
 #![feature(alloc)]
 
 include!("crates.rs");

--- a/pumpkindb_engine/src/script/dispatcher.rs
+++ b/pumpkindb_engine/src/script/dispatcher.rs
@@ -15,8 +15,6 @@ pub trait Dispatcher<'a> {
     fn handle(&mut self, env: &mut Env<'a>, instruction: &'a [u8], pid: EnvId) -> PassResult<'a>;
 }
 
-include!("macros.rs");
-
 impl<'a> Dispatcher<'a> for Vec<Box<Dispatcher<'a>>> {
     fn init(&mut self, env: &mut Env<'a>, pid: EnvId) {
         for mut disp in self.into_iter() {

--- a/pumpkindb_engine/src/script/mod.rs
+++ b/pumpkindb_engine/src/script/mod.rs
@@ -59,6 +59,8 @@
 //!   from carrying these references outside of the scope of the transaction)
 //!
 
+#[macro_use]
+pub mod macros;
 pub mod envheap;
 pub mod dispatcher;
 pub use self::dispatcher::Dispatcher;
@@ -85,8 +87,6 @@ macro_rules! instruction {
 
 instruction!(TRY, b"\x83TRY");
 instruction!(TRY_END, b"\x80\x83TRY"); // internal instruction
-
-include!("macros.rs");
 
 pub trait TryInstruction {
     fn if_unhandled_try<F>(self, f: F) -> Result<(), Error> where F: FnOnce() -> Result<(), Error>;

--- a/pumpkindb_mio_server/Cargo.toml
+++ b/pumpkindb_mio_server/Cargo.toml
@@ -12,6 +12,7 @@ authors = ["Yurii Rashkovskii <yrashk@gmail.com>"]
 
 [dependencies]
 mio = "0.6.4"
+mio-extras = "2.0.5"
 byteorder = "1.0.0"
 memmap = "0.5.2"
 slab = "0.3.0"

--- a/pumpkindb_mio_server/src/lib.rs
+++ b/pumpkindb_mio_server/src/lib.rs
@@ -3,9 +3,10 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#![feature(slice_patterns, advanced_slice_patterns)]
+#![feature(slice_patterns)]
 
 extern crate mio;
+extern crate mio_extras;
 extern crate memmap;
 extern crate byteorder;
 extern crate rand;
@@ -25,7 +26,7 @@ mod server;
 use mio::Poll;
 use mio::tcp::TcpListener;
 
-use mio::channel as mio_chan;
+use mio_extras::channel as mio_chan;
 
 use pumpkindb_engine::{script};
 

--- a/pumpkindb_mio_server/src/server.rs
+++ b/pumpkindb_mio_server/src/server.rs
@@ -4,15 +4,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::collections::BTreeMap;
 use std::io;
 use std::rc::Rc;
 use std::sync::mpsc;
-use std::collections::BTreeMap;
 
 use slab;
-use mio::channel as mio_chan;
+use mio_extras::channel as mio_chan;
+use mio::net::*;
 use mio::*;
-use mio::tcp::*;
 
 use super::connection::Connection;
 

--- a/pumpkindb_server/Cargo.toml
+++ b/pumpkindb_server/Cargo.toml
@@ -23,6 +23,7 @@ num_cpus = "1.3.0"
 log = "0.3.6"
 log4rs = { version = "0.6.1", features = ["toml_format"] }
 mio = "0.6.4"
+mio-extras = "2.0.5"
 
 pumpkindb_engine = { version = "0.2", path = "../pumpkindb_engine" }
 pumpkindb_mio_server = { version = "0.2", path = "../pumpkindb_mio_server" }

--- a/pumpkindb_server/src/main.rs
+++ b/pumpkindb_server/src/main.rs
@@ -15,6 +15,7 @@ extern crate num_cpus;
 extern crate log;
 extern crate log4rs;
 extern crate mio;
+extern crate mio_extras;
 
 extern crate pumpkindb_mio_server as server;
 
@@ -29,7 +30,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use mio::channel as mio_chan;
+use mio_extras::channel as mio_chan;
 
 
 lazy_static! {


### PR DESCRIPTION
Solution: bump dependency versions and update module imports based on compiler errors.